### PR TITLE
add wildcard DNS entry support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
         "DEBUG": "true",
         "INSTANCE_IP": "0.0.0.0"
     },
-    "go.testFlags": ["-count=100", "-failfast"],
+    "go.testFlags": ["-count=1", "-failfast"],
     "gitlens.autolinks": [
         {
             "alphanumeric": true,

--- a/pkg/roles/dns/handler_etcd_test.go
+++ b/pkg/roles/dns/handler_etcd_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRoleDNSHandlerEtcd(t *testing.T) {
+func TestRoleDNS_Etcd(t *testing.T) {
+	tests.ResetEtcd(t)
 	rootInst := instance.New()
 	ctx := tests.Context()
 	inst := rootInst.ForRole("dns", ctx)
@@ -52,4 +53,92 @@ func TestRoleDNSHandlerEtcd(t *testing.T) {
 
 	tests.WaitForPort(1054)
 	assert.Equal(t, []string{"10.1.2.3"}, tests.DNSLookup("foo.", extconfig.Get().Listen(1054)))
+}
+
+func TestRoleDNS_Etcd_Wildcard(t *testing.T) {
+	tests.ResetEtcd(t)
+	rootInst := instance.New()
+	ctx := tests.Context()
+	inst := rootInst.ForRole("dns", ctx)
+	inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyZones,
+			".",
+		).String(),
+		tests.MustJSON(dns.Zone{
+			HandlerConfigs: []map[string]string{
+				{
+					"type": "etcd",
+				},
+			},
+		}),
+	)
+	inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyZones,
+			".",
+			"*",
+			types.DNSRecordTypeA,
+			"0",
+		).String(),
+		tests.MustJSON(dns.Record{
+			Data: "10.1.2.3",
+		}),
+	)
+
+	role := dns.New(inst)
+	assert.NotNil(t, role)
+	assert.Nil(t, role.Start(ctx, RoleConfig()))
+	defer role.Stop()
+
+	tests.WaitForPort(1054)
+	assert.Equal(t, []string{"10.1.2.3"}, tests.DNSLookup("foo.", extconfig.Get().Listen(1054)))
+}
+
+func TestRoleDNS_Etcd_WildcardNested(t *testing.T) {
+	tests.ResetEtcd(t)
+	rootInst := instance.New()
+	ctx := tests.Context()
+	inst := rootInst.ForRole("dns", ctx)
+	inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyZones,
+			".",
+		).String(),
+		tests.MustJSON(dns.Zone{
+			HandlerConfigs: []map[string]string{
+				{
+					"type": "etcd",
+				},
+			},
+		}),
+	)
+	inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyZones,
+			".",
+			"*.*",
+			types.DNSRecordTypeA,
+			"0",
+		).String(),
+		tests.MustJSON(dns.Record{
+			Data: "10.1.2.3",
+		}),
+	)
+
+	role := dns.New(inst)
+	assert.NotNil(t, role)
+	assert.Nil(t, role.Start(ctx, RoleConfig()))
+	defer role.Stop()
+
+	tests.WaitForPort(1054)
+	assert.Equal(t, []string{"10.1.2.3"}, tests.DNSLookup("foo.bar.", extconfig.Get().Listen(1054)))
 }

--- a/pkg/roles/dns/types/role.go
+++ b/pkg/roles/dns/types/role.go
@@ -11,3 +11,7 @@ const (
 	DNSRecordTypePTR   = "PTR"
 	DNSRecordTypeCNAME = "CNAME"
 )
+
+const (
+	DNSWildcard = "*"
+)


### PR DESCRIPTION
closes #349

supports n-level wildcards

looking up `foo.zone.tld` checks `/zone.tld/foo/A` and also `/zone.tld/*/A` 

looking up `foo.bar.zone.tld` checks `/zone.tld/foo.bar/A`, `/zone.tld/*.bar/A` and `/zone.tld/*.*/A`