### PR TITLE
Clearer installation documentation

### DIFF
--- a/docs/content/docs/install/_index.md
+++ b/docs/content/docs/install/_index.md
@@ -1,3 +1,4 @@
+
 ---
 title: "Installation"
 weight: 5
@@ -6,6 +7,7 @@ weight: 5
 ### Installation
 
 #### docker-compose
+Create a file called `docker-compose.yml` in a new directory with the following content:
 
 ```yaml
 ---
@@ -34,10 +36,12 @@ volumes:
   data:
     driver: local
 ```
+Run with `docker compose up -d`
 
 ## First time use
+A default admin user is created on the first startup. You can find the credentials printed to stdout. You can access these by running `docker logs <docker container name>`
 
-A default admin user is created on the first startup. You can find the credentials printed to stdout.
+You can reach Gravity by going to `http://<server IP or hostname>:8008` in your browser.
 
 ### Configuration
 
@@ -45,7 +49,7 @@ The following environment variables can be set
 
 ##### Common
 
-- `BOOTSTRAP_ROLES`: Configure while roles this instance should bootstrap, defaults to `dns;dhcp;api;etcd;discovery;backup;monitoring;tsdb`.
+- `BOOTSTRAP_ROLES`: Configure which roles this instance should bootstrap, defaults to `dns;dhcp;api;etcd;discovery;backup;monitoring;tsdb`.
 - `LOG_LEVEL`: Log level, defaults to `info`.
 - `DATA_PATH`: Path to store etcd data, defaults to `./data`
 - `INSTANCE_IDENTIFIER`: Unique identifier of an instance, should ideally not change. Defaults to hostname. When running in docker, this is configured via the `hostname` attribute.
@@ -63,3 +67,14 @@ The following environment variables can be set
 - `ADMIN_TOKEN`: Optionally set a token to be created on first start, if not set no token will be created
 - `SENTRY_ENABLED`: Enable sentry error reporting and tracing
 - `SENTRY_DSN`: Configure a custom sentry DSN
+
+##### Changing Environmental variables
+Environmental variables can be added by modifying the `environment:` options in the compose file. Gravity is made so you ideally don't have to set these.
+
+Example:
+```yaml
+    environment:
+      INSTANCE_IP: 192.168.2.8
+      BOOTSTRAP_ROLES: dns;api;etcd;discovery;monitoring;tsdb
+      INSTANCE_IDENTIFIER: My-DNS-Server
+```

--- a/docs/content/docs/install/_index.md
+++ b/docs/content/docs/install/_index.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Installation"
 weight: 5
@@ -7,6 +6,7 @@ weight: 5
 ### Installation
 
 #### docker-compose
+
 Create a file called `docker-compose.yml` in a new directory with the following content:
 
 ```yaml
@@ -36,10 +36,12 @@ volumes:
   data:
     driver: local
 ```
-Run with `docker compose up -d`
+
+Run `docker compose up -d` to start gravity.
 
 ## First time use
-A default admin user is created on the first startup. You can find the credentials printed to stdout. You can access these by running `docker logs <docker container name>`
+
+A default admin user is created on the first startup. You can find the credentials printed to stdout. You can access these by running `docker compose logs`.
 
 You can reach Gravity by going to `http://<server IP or hostname>:8008` in your browser.
 
@@ -69,6 +71,7 @@ The following environment variables can be set
 - `SENTRY_DSN`: Configure a custom sentry DSN
 
 ##### Changing Environmental variables
+
 Environmental variables can be added by modifying the `environment:` options in the compose file. Gravity is made so you ideally don't have to set these.
 
 Example:
@@ -76,5 +79,5 @@ Example:
     environment:
       INSTANCE_IP: 192.168.2.8
       BOOTSTRAP_ROLES: dns;api;etcd;discovery;monitoring;tsdb
-      INSTANCE_IDENTIFIER: My-DNS-Server
+      INSTANCE_IDENTIFIER: my-gravity-server
 ```


### PR DESCRIPTION
Added short instructions for compose file.
Added instructions for finding admin account credentials. Added example link to reach web interface.
Added instructions for changing the environmental variables with small example with disclaimer that you most likely don't need to edit these. Changed small typo, while>which.