### PR TITLE
docs/dhcp: document default DHCP option values

### DIFF
--- a/docs/content/docs/dhcp/options.md
+++ b/docs/content/docs/dhcp/options.md
@@ -64,7 +64,14 @@ Example:
 
 Gravity applies some default options when not explicitly configured in the scope settings, but will always prefer user-configured settings if available.
 
-### DNS server
+### Subnet Mask
+
+- Tag name: `subnet_mask`
+- Tag: `1`
+
+This option defaults to the CIDR configured for the scope.
+
+### DNS Server
 
 - Tag name: `name_server`
 - Tag: `6`
@@ -81,3 +88,9 @@ If the scope is configured with a domain name and `addZoneInHostname` is `true`,
 
 - Example with scope default options: `somehost`
 - Example when scope has `addZoneInHostname` enabled: `somehost.example.com`
+
+### IP Address Lease Time
+
+- Tag: `51`
+
+This option defaults to the TTL configured for the scope.

--- a/docs/content/docs/dhcp/options.md
+++ b/docs/content/docs/dhcp/options.md
@@ -59,3 +59,25 @@ Example:
 ```
 
 *Conflicts with `value`*
+
+## Defaults
+
+Gravity applies some default options when not explicitly configured in the scope settings, but will always prefer user-configured settings if available.
+
+### DNS server
+
+- Tag name: `name_server`
+- Tag: `6`
+
+This option defaults to the IP address of the Gravity instance responding to a DHCPREQUEST.
+
+### Hostname
+
+- Tag: `12`
+
+This option defaults to the hostname provided by the client in the DHCPREQUEST.
+
+If the scope is configured with a domain name and `addZoneInHostname` is `true`, the domain name is appended to the client-provided hostname to form a fully qualified domain name (FQDN), as described [here](../scopes/#dns).
+
+- Example with scope default options: `somehost`
+- Example when scope has `addZoneInHostname` enabled: `somehost.example.com`

--- a/docs/content/docs/dhcp/options.md
+++ b/docs/content/docs/dhcp/options.md
@@ -69,7 +69,7 @@ Gravity applies some default options when not explicitly configured in the scope
 - Tag name: `subnet_mask`
 - Tag: `1`
 
-This option defaults to the CIDR configured for the scope.
+This option defaults to the subnet mask from the CIDR configured for the scope.
 
 ### DNS Server
 

--- a/docs/content/docs/dhcp/scopes.md
+++ b/docs/content/docs/dhcp/scopes.md
@@ -32,7 +32,7 @@ Example options:
   value: 10.1.2.3
 ```
 
-More info [here](./scopes.md).
+More info and default values can be found [here](../options).
 
 #### `ttl`
 


### PR DESCRIPTION
These are the defaults I discovered, let me know if I missed anything.

I chose not to document the default values for tagName router and tagName subnet since these are obvious based on the input fields in the scope config interface.