### PR TITLE
update lease when device moves to different network

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,7 @@ jobs:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
+      - run: make install-deps
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,10 @@ jobs:
         run: |
           npm ci
           npm run build
-      - name: Setup test env
-        run: make test-env-start
-      - name: Run tests & coverage
-        run: |
-          make install-deps test
-      - name: Stop test env
-        if: ${{ always() }}
+      - run: make test-env-start
+      - run: make install-deps
+      - run: make test
+      - if: ${{ always() }}
         run: make test-env-stop
       - if: ${{ always() }}
         uses: codecov/codecov-action@v3
@@ -55,10 +52,7 @@ jobs:
         run: |
           npm ci
           npm run build
-      - name: Install deps
-        run: |
-          make install-deps
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - run: make install-deps
+      - uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout 5000s

--- a/pkg/roles/api/api_transport.go
+++ b/pkg/roles/api/api_transport.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"beryju.io/gravity/pkg/extconfig"
+	instanceTypes "beryju.io/gravity/pkg/instance/types"
 	apiTypes "beryju.io/gravity/pkg/roles/api/types"
 	tsdbTypes "beryju.io/gravity/pkg/roles/tsdb/types"
 	"github.com/swaggest/usecase"
@@ -31,6 +32,8 @@ func (r *Role) ignoredPrefixes() []string {
 		r.i.KV().Key(apiTypes.KeyRole, apiTypes.KeySessions).String(),
 		r.i.KV().Key(apiTypes.KeyRole, apiTypes.KeyTokens).String(),
 		r.i.KV().Key(apiTypes.KeyRole, apiTypes.KeyUsers).String(),
+		// Contains API role config (cookie secret, OIDC config)
+		r.i.KV().Key(instanceTypes.KeyInstance, instanceTypes.KeyRole, apiTypes.KeyRole).String(),
 		// Noisy data we don't need
 		r.i.KV().Key(tsdbTypes.KeyRole, tsdbTypes.KeySystem).String(),
 	}

--- a/pkg/roles/api/api_transport_test.go
+++ b/pkg/roles/api/api_transport_test.go
@@ -29,7 +29,9 @@ func TestExport(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	err = role.APIClusterExport().Interact(ctx, api.APIExportInput{}, &output)
+	err = role.APIClusterExport().Interact(ctx, api.APIExportInput{
+		Safe: true,
+	}, &output)
 	assert.NoError(t, err)
 	assert.Equal(t, api.APIExportOutput{
 		Entries: []api.APITransportEntry{

--- a/pkg/roles/api/api_transport_test.go
+++ b/pkg/roles/api/api_transport_test.go
@@ -29,7 +29,7 @@ func TestExport(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	err = role.APIClusterExport().Interact(ctx, struct{}{}, &output)
+	err = role.APIClusterExport().Interact(ctx, api.APIExportInput{}, &output)
 	assert.NoError(t, err)
 	assert.Equal(t, api.APIExportOutput{
 		Entries: []api.APITransportEntry{

--- a/pkg/roles/dhcp/dhcp_handler4_request.go
+++ b/pkg/roles/dhcp/dhcp_handler4_request.go
@@ -31,13 +31,3 @@ func (r *Role) HandleDHCPRequest4(req *Request4) *dhcpv4.DHCPv4 {
 	rep.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeAck))
 	return rep
 }
-
-func (r *Role) FindLease(req *Request4) *Lease {
-	r.leasesM.RLock()
-	defer r.leasesM.RUnlock()
-	lease, ok := r.leases[r.DeviceIdentifier(req.DHCPv4)]
-	if !ok {
-		return nil
-	}
-	return lease
-}

--- a/pkg/roles/dhcp/ipam.go
+++ b/pkg/roles/dhcp/ipam.go
@@ -6,7 +6,11 @@ import (
 )
 
 type IPAM interface {
+	// Return the next free IP address, could be sequential or random
 	NextFreeAddress() *netip.Addr
+	// Check if IP address is in usage (should also check if IP is in specified range and subnet)
+	// Can optionally also check if the IP address is pingable
 	IsIPFree(netip.Addr) bool
+	// Get the subnet mask of the scope
 	GetSubnetMask() net.IPMask
 }


### PR DESCRIPTION
closes #762

Previously, when a device moved to a different network while keeping the same identifier, it would get the same lease it did before, even if that lease was not in the new scope the device is now in.

This adds a check to ensure that before a lease is returned, it must be in the same scope that would be picked for a new device. If that isn't the case, the lease is updated to use the new scope, and gets a new address assigned. All other options of the lease are kept as they were, including expiry and reservation status