### PR TITLE
correctly support CNAMEs

### DIFF
--- a/pkg/roles/discovery/api_devices_test.go
+++ b/pkg/roles/discovery/api_devices_test.go
@@ -275,7 +275,9 @@ func TestDeviceApplyDNSWithReverse(t *testing.T) {
 
 	// Create DNS role to register events
 	dnsRole := dns.New(rootInst.ForRole("dns", ctx))
-	tests.PanicIfError(dnsRole.Start(ctx, []byte{}))
+	tests.PanicIfError(dnsRole.Start(ctx, []byte(tests.MustJSON(dns.RoleConfig{
+		Port: 1054,
+	}))))
 	defer dnsRole.Stop()
 
 	role := discovery.New(inst)

--- a/pkg/roles/dns/handler_etcd.go
+++ b/pkg/roles/dns/handler_etcd.go
@@ -105,6 +105,9 @@ func (eh *EtcdHandler) handleSingleQuestion(question dns.Question, r *utils.DNSR
 		r,
 	)...)
 	// Look for CNAMEs
+	// This section has room for optimization, as for we currently check for the existence
+	// of CNAMEs for each question, which is a bit pointless if there are questions for foo.bar/A
+	// and foo.bar/AAAA, and we also do the recursion for each question
 	cnames := eh.lookupKey(
 		eh.z.inst.KV().Key(
 			eh.z.etcdKey,
@@ -122,7 +125,6 @@ func (eh *EtcdHandler) handleSingleQuestion(question dns.Question, r *utils.DNSR
 			nq := dns.Question{
 				Name: cn.Target,
 			}
-			eh.log.Debug(cn.Header().Name)
 			answers = append(answers, eh.handleSingleQuestion(nq, r, level+1)...)
 		}
 	}

--- a/pkg/roles/dns/handler_etcd.go
+++ b/pkg/roles/dns/handler_etcd.go
@@ -14,6 +14,8 @@ import (
 
 const EtcdType = "etcd"
 
+const CNameRecursionMax = 10
+
 type EtcdHandler struct {
 	log *zap.Logger
 	z   *Zone
@@ -48,10 +50,85 @@ func (eh *EtcdHandler) lookupKey(k *storage.Key, question dns.Question, r *utils
 		if err != nil {
 			continue
 		}
-		ans := rec.ToDNS(question.Name, question.Qtype)
+		ans := rec.ToDNS(question.Name)
 		if ans != nil {
 			answers = append(answers, ans)
 		}
+	}
+	return answers
+}
+
+func (eh *EtcdHandler) findWildcard(r *utils.DNSRequest, relRecordName string, question dns.Question) []dns.RR {
+	// Assuming the question is foo.bar.baz and the zone is baz,
+	// we'll try replacing all names from left to right by starts and query with that
+	wildcardName := relRecordName
+	parts := strings.Split(relRecordName, ".")
+	for _, part := range parts {
+		// Replace the current dot part with a wildcard (make sure to only replace 1 occurrence,
+		// since we replace from left to right)
+		wildcardName = strings.Replace(wildcardName, part, types.DNSWildcard, 1)
+		wildcardKey := eh.z.inst.KV().Key(eh.z.etcdKey, strings.ToLower(wildcardName), dns.Type(question.Qtype).String())
+		wildcardAns := eh.lookupKey(wildcardKey, question, r)
+		// If we do get an answer from this wildcard key, stop going further
+		if len(wildcardAns) > 0 {
+			return wildcardAns
+		}
+	}
+	return []dns.RR{}
+}
+
+func (eh *EtcdHandler) handleSingleQuestion(question dns.Question, r *utils.DNSRequest, level int) []dns.RR {
+	answers := []dns.RR{}
+	if level >= CNameRecursionMax {
+		eh.log.Info("stopping cname recursion at level", zap.Int("max", CNameRecursionMax))
+		return answers
+	}
+	relRecordName := strings.TrimSuffix(strings.ToLower(question.Name), strings.ToLower(utils.EnsureLeadingPeriod(eh.z.Name)))
+	directRecordKey := eh.z.inst.KV().Key(
+		eh.z.etcdKey,
+		strings.ToLower(relRecordName),
+	)
+	if question.Qtype != dns.TypeNone {
+		// If we're looking for a specific key, include that in the etcd key
+		directRecordKey = directRecordKey.Add(dns.Type(question.Qtype).String())
+	} else {
+		// otherwise turn the query into a prefix
+		// this is most likely to happen due to a CNAME query, where we don't know if its
+		// name points to an A, AAAA or anything else (realistically it should be either
+		// of those)
+		directRecordKey = directRecordKey.Prefix(true)
+	}
+	// Look for direct matches first
+	answers = append(answers, eh.lookupKey(
+		directRecordKey,
+		question,
+		r,
+	)...)
+	// Look for CNAMEs
+	cnames := eh.lookupKey(
+		eh.z.inst.KV().Key(
+			eh.z.etcdKey,
+			strings.ToLower(relRecordName),
+			dns.Type(dns.TypeCNAME).String(),
+		),
+		question,
+		r,
+	)
+	if len(cnames) > 0 {
+		answers = append(answers, cnames...)
+		// For each cname, lookup the actual record
+		for _, _cn := range cnames {
+			cn := _cn.(*dns.CNAME)
+			nq := dns.Question{
+				Name: cn.Target,
+			}
+			eh.log.Debug(cn.Header().Name)
+			answers = append(answers, eh.handleSingleQuestion(nq, r, level+1)...)
+		}
+	}
+	// If we don't find an answer for the direct key lookup, try a wildcard lookup
+	if len(answers) < 1 {
+		answers = append(answers, eh.findWildcard(r, relRecordName, question)...)
 	}
 	return answers
 }
@@ -60,30 +137,7 @@ func (eh *EtcdHandler) Handle(w *utils.FakeDNSWriter, r *utils.DNSRequest) *dns.
 	m := new(dns.Msg)
 	m.Authoritative = eh.z.Authoritative
 	for _, question := range r.Question {
-		relRecordName := strings.TrimSuffix(strings.ToLower(question.Name), strings.ToLower(utils.EnsureLeadingPeriod(eh.z.Name)))
-		fullRecordKey := eh.z.inst.KV().Key(eh.z.etcdKey, strings.ToLower(relRecordName), dns.Type(question.Qtype).String())
-		ans := eh.lookupKey(fullRecordKey, question, r)
-		// If we don't find an answer for the direct key lookup, try a wildcard lookup
-		if len(ans) < 1 {
-			// Assuming the question is foo.bar.baz and the zone is baz,
-			// we'll try replacing all names from left to right by starts and query with that
-			wildcardName := relRecordName
-			parts := strings.Split(relRecordName, ".")
-			for _, part := range parts {
-				// Replace the current dot part with a wildcard (make sure to only replace 1 occurrence,
-				// since we replace from left to right)
-				wildcardName = strings.Replace(wildcardName, part, types.DNSWildcard, 1)
-				wildcardKey := eh.z.inst.KV().Key(eh.z.etcdKey, strings.ToLower(wildcardName), dns.Type(question.Qtype).String())
-				wildcardAns := eh.lookupKey(wildcardKey, question, r)
-				// If we do get an answer from this wildcard key, stop going further
-				if len(wildcardAns) > 0 {
-					m.Answer = append(m.Answer, wildcardAns...)
-					break
-				}
-			}
-		} else {
-			m.Answer = append(m.Answer, ans...)
-		}
+		m.Answer = append(m.Answer, eh.handleSingleQuestion(question, r, 0)...)
 	}
 	if len(m.Answer) < 1 {
 		return nil

--- a/pkg/roles/dns/handler_memory.go
+++ b/pkg/roles/dns/handler_memory.go
@@ -45,7 +45,7 @@ func (eh *MemoryHandler) Handle(w *utils.FakeDNSWriter, r *utils.DNSRequest) *dn
 			}
 			eh.log.Debug("got record in in-memory cache", zap.String("key", fullRecordKey))
 			for _, rec := range recs {
-				ans := rec.ToDNS(question.Name, question.Qtype)
+				ans := rec.ToDNS(question.Name)
 				if ans != nil {
 					m.Answer = append(m.Answer, ans)
 				}

--- a/pkg/roles/dns/record.go
+++ b/pkg/roles/dns/record.go
@@ -64,15 +64,35 @@ func (z *Zone) newRecord(name string, t string) *Record {
 	}
 }
 
-func (r *Record) ToDNS(qname string, t uint16) dns.RR {
+func (r *Record) RRType() uint16 {
+	switch strings.ToLower(r.Type) {
+	case "a":
+		return dns.TypeA
+	case "aaaa":
+		return dns.TypeAAAA
+	case "ptr":
+		return dns.TypePTR
+	case "srv":
+		return dns.TypeSRV
+	case "mx":
+		return dns.TypeMX
+	case "cname":
+		return dns.TypeCNAME
+	case "txt":
+		return dns.TypeTXT
+	}
+	return dns.TypeNone
+}
+
+func (r *Record) ToDNS(qname string) dns.RR {
 	hdr := dns.RR_Header{
 		Name:   qname,
-		Rrtype: t,
+		Rrtype: r.RRType(),
 		Class:  dns.ClassINET,
 		Ttl:    r.TTL,
 	}
 	var rr dns.RR
-	switch t {
+	switch r.RRType() {
 	case dns.TypeA:
 		rr = &dns.A{}
 		rr.(*dns.A).Hdr = hdr

--- a/pkg/roles/dns/role_config_test.go
+++ b/pkg/roles/dns/role_config_test.go
@@ -14,7 +14,7 @@ func TestAPIRoleConfigGet(t *testing.T) {
 	ctx := tests.Context()
 	inst := rootInst.ForRole("dns", ctx)
 	role := dns.New(inst)
-	tests.PanicIfError(role.Start(ctx, []byte{}))
+	tests.PanicIfError(role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
 	var output dns.APIRoleConfigOutput
@@ -27,7 +27,7 @@ func TestAPIRoleConfigPut(t *testing.T) {
 	ctx := tests.Context()
 	inst := rootInst.ForRole("dns", ctx)
 	role := dns.New(inst)
-	tests.PanicIfError(role.Start(ctx, []byte{}))
+	tests.PanicIfError(role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
 	assert.NoError(t, role.APIRoleConfigPut().Interact(ctx, dns.APIRoleConfigInput{

--- a/pkg/roles/dns/role_test.go
+++ b/pkg/roles/dns/role_test.go
@@ -21,7 +21,7 @@ func TestRoleDNSStartNoConfig(t *testing.T) {
 	inst := rootInst.ForRole("dns", ctx)
 	role := dns.New(inst)
 	assert.NotNil(t, role)
-	assert.Nil(t, role.Start(ctx, []byte{}))
+	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	role.Stop()
 }
 


### PR DESCRIPTION
closes #611

Also query for CNAME records when querying, and if any CNAME records are found, gravity will look those up too and return those too. The limit is hardcoded to 10 levels deep, which is more than should realistically be needed