### PR TITLE
Rework IPAM and fix concurrent IP race conditions

### DIFF
--- a/pkg/roles/dhcp/api_scopes.go
+++ b/pkg/roles/dhcp/api_scopes.go
@@ -117,7 +117,7 @@ func (r *Role) APIScopesPut() usecase.Interactor {
 		}
 		s.cidr = cidr
 
-		_, err = s.ipamType()
+		_, err = s.ipamType(nil)
 		if err != nil {
 			return status.Wrap(err, status.InvalidArgument)
 		}

--- a/pkg/roles/dhcp/api_scopes_test.go
+++ b/pkg/roles/dhcp/api_scopes_test.go
@@ -12,6 +12,7 @@ import (
 
 func testScope() dhcp.Scope {
 	return dhcp.Scope{
+		Name:       tests.RandomString(),
 		SubnetCIDR: "10.200.0.0/24",
 		Default:    true,
 		Options: []*types.DHCPOption{

--- a/pkg/roles/dhcp/ipam.go
+++ b/pkg/roles/dhcp/ipam.go
@@ -17,4 +17,6 @@ type IPAM interface {
 	GetSubnetMask() net.IPMask
 	// Mark an IP as used
 	UseIP(addr netip.Addr, identifier string)
+	// Update config when scope is updated
+	UpdateConfig(s *Scope) error
 }

--- a/pkg/roles/dhcp/ipam.go
+++ b/pkg/roles/dhcp/ipam.go
@@ -7,10 +7,14 @@ import (
 
 type IPAM interface {
 	// Return the next free IP address, could be sequential or random
-	NextFreeAddress() *netip.Addr
+	NextFreeAddress(identifier string) *netip.Addr
 	// Check if IP address is in usage (should also check if IP is in specified range and subnet)
 	// Can optionally also check if the IP address is pingable
-	IsIPFree(netip.Addr) bool
+	// `identifier` might be given as well for a device that could request an address
+	// that it had already taken
+	IsIPFree(addr netip.Addr, identifier *string) bool
 	// Get the subnet mask of the scope
 	GetSubnetMask() net.IPMask
+	// Mark an IP as used
+	UseIP(addr netip.Addr, identifier string)
 }

--- a/pkg/roles/dhcp/ipam_internal.go
+++ b/pkg/roles/dhcp/ipam_internal.go
@@ -14,17 +14,22 @@ import (
 
 const InternalIPAMType = "internal"
 
+type IPUse struct {
+	identifier string
+	unknown    bool
+}
+
 type InternalIPAM struct {
 	Start netip.Addr
 	End   netip.Addr
 
-	ips map[string]bool
+	ips map[string]*IPUse
 
 	log        *zap.Logger
 	role       *Role
 	scope      *Scope
 	SubnetCIDR netip.Prefix
-	ipsy       sync.RWMutex
+	ipsm       sync.RWMutex
 
 	shouldPing bool
 }
@@ -49,8 +54,8 @@ func NewInternalIPAM(role *Role, s *Scope) (*InternalIPAM, error) {
 		log:        role.log.With(zap.String("ipam", "internal")),
 		role:       role,
 		scope:      s,
-		ips:        make(map[string]bool),
-		ipsy:       sync.RWMutex{},
+		ips:        make(map[string]*IPUse),
+		ipsm:       sync.RWMutex{},
 	}
 	sp := s.IPAM["should_ping"]
 	if sp != "" {
@@ -63,44 +68,68 @@ func NewInternalIPAM(role *Role, s *Scope) (*InternalIPAM, error) {
 	return ipam, nil
 }
 
-func (i *InternalIPAM) NextFreeAddress() *netip.Addr {
-	initialIp := i.Start
+func (i *InternalIPAM) NextFreeAddress(identifier string) *netip.Addr {
+	currentIP := i.Start
 	for {
 		// Since we start checking at the beginning of the range, check in the loop if we've
 		// hit the end and just give up, as the range is full
-		if i.End.Compare(initialIp) == -1 {
+		if i.End.Compare(currentIP) == -1 {
 			break
 		}
-		i.log.Debug("checking for free ip", zap.String("ip", initialIp.String()))
+		i.log.Debug("checking for free IP", zap.String("ip", currentIP.String()))
 		// Check if IP is in the correct subnet
-		if !i.SubnetCIDR.Contains(initialIp) {
-			return nil
+		if !i.SubnetCIDR.Contains(currentIP) {
+			break
 		}
-		if i.IsIPFree(initialIp) {
-			return &initialIp
-		} else {
-			i.ipsy.Lock()
-			i.ips[initialIp.String()] = true
-			i.ipsy.Unlock()
+		if i.IsIPFree(currentIP, &identifier) {
+			// Actually mark IP as used
+			// i.UseIP(currentIP, identifier)
+			return &currentIP
 		}
-		initialIp = initialIp.Next()
+		// As the IP is not free we're marking it as used, however this is a fallback if
+		// `IsIPFree` didn't mark the IP as used by a specific lease
+		i.useIP(currentIP, IPUse{
+			identifier: identifier,
+			unknown:    true,
+		}, false)
+		currentIP = currentIP.Next()
 	}
+	i.log.Warn("no more empty IPs left", zap.String("lastIp", currentIP.String()))
 	return nil
 }
 
-func (i *InternalIPAM) IsIPFree(ip netip.Addr) bool {
-	if i.ips[ip.String()] {
-		i.log.Debug("discarding", zap.String("reason", "used (in memory)"))
+func (i *InternalIPAM) UseIP(ip netip.Addr, identifier string) {
+	i.useIP(ip, IPUse{
+		identifier: identifier,
+		unknown:    false,
+	}, true)
+}
+
+func (i *InternalIPAM) useIP(ip netip.Addr, ipu IPUse, overwrite bool) {
+	i.ipsm.Lock()
+	defer i.ipsm.Unlock()
+	if i.ips[ip.String()] != nil && !overwrite {
+		return
+	}
+	i.ips[ip.String()] = &ipu
+}
+
+func (i *InternalIPAM) IsIPFree(ip netip.Addr, identifier *string) bool {
+	i.ipsm.RLock()
+	mem := i.ips[ip.String()]
+	i.ipsm.RUnlock()
+	if mem != nil {
+		i.log.Debug("discarding", zap.String("ip", ip.String()), zap.String("reason", "used (in memory)"))
 		return false
 	}
 	// Ip is less than the start of the range
 	if i.Start.Compare(ip) == 1 {
-		i.log.Debug("discarding", zap.String("reason", "before started"))
+		i.log.Debug("discarding", zap.String("ip", ip.String()), zap.String("reason", "before started"))
 		return false
 	}
 	// Ip is more than the end of the range
 	if i.End.Compare(ip) == -1 {
-		i.log.Debug("discarding", zap.String("reason", "after end"))
+		i.log.Debug("discarding", zap.String("ip", ip.String()), zap.String("reason", "after end"))
 		return false
 	}
 	// check for existing leases
@@ -109,34 +138,50 @@ func (i *InternalIPAM) IsIPFree(ip netip.Addr) bool {
 		if l.ScopeKey != i.scope.Name {
 			continue
 		}
-		if l.Address == ip.String() {
-			i.log.Debug("discarding", zap.String("reason", "existing lease"))
-			return false
+		if l.Address != ip.String() {
+			continue
 		}
+		if identifier != nil && l.Identifier == *identifier {
+			i.UseIP(ip, *identifier)
+			return true
+		}
+		i.log.Debug("discarding", zap.String("ip", ip.String()), zap.String("reason", "existing lease"))
+		return false
 	}
-	// By default, we dont try to ping the "free" IP
-	// and at this point we're confident that it's free
-	if !i.shouldPing {
-		return true
+	// check for ping
+	if i.shouldPing && i.ping(ip) {
+		return false
 	}
+	if identifier != nil {
+		i.useIP(ip, IPUse{
+			identifier: *identifier,
+			unknown:    true,
+		}, false)
+	}
+	return true
+}
+
+// Attempt to ping the IP. If we can ping the IP successfully, return true, and if we fail
+// for any reason return false
+func (i *InternalIPAM) ping(ip netip.Addr) bool {
 	pinger, err := ping.NewPinger(ip.String())
 	if err != nil {
 		i.log.Warn("failed to ping IP", zap.Error(err))
-		return true
+		return false
 	}
 	pinger.Count = 1
 	pinger.Timeout = 1 * time.Second
 	pings := false
 	pinger.OnRecv = func(pkt *ping.Packet) {
-		i.log.Debug("discarding", zap.String("reason", "pings"))
-		pings = true
+		i.log.Debug("discarding", zap.String("ip", ip.String()), zap.String("reason", "pings"))
+		pings = false
 	}
 	err = pinger.Run()
 	if err != nil {
 		i.log.Debug("failed to ping ip", zap.Error(err))
 		return false
 	}
-	return !pings
+	return pings
 }
 
 func (i *InternalIPAM) GetSubnetMask() net.IPMask {

--- a/pkg/roles/dhcp/ipam_internal_test.go
+++ b/pkg/roles/dhcp/ipam_internal_test.go
@@ -1,0 +1,114 @@
+package dhcp_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"beryju.io/gravity/pkg/instance"
+	"beryju.io/gravity/pkg/roles/dhcp"
+	"beryju.io/gravity/pkg/roles/dhcp/types"
+	"beryju.io/gravity/pkg/tests"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
+)
+
+func TestIPAMInternal(t *testing.T) {
+	defer tests.Setup(t)()
+	rootInst := instance.New()
+	ctx := tests.Context()
+	inst := rootInst.ForRole("dhcp", ctx)
+	role := dhcp.New(inst)
+	scope := testScope()
+	ipam, err := dhcp.NewInternalIPAM(role, &scope)
+	assert.NoError(t, err)
+	assert.NotNil(t, ipam)
+}
+
+func TestIPAMInternal_NextFreeAddress(t *testing.T) {
+	defer tests.Setup(t)()
+	rootInst := instance.New()
+	ctx := tests.Context()
+	inst := rootInst.ForRole("dhcp", ctx)
+	role := dhcp.New(inst)
+	scope := testScope()
+	ipam, err := dhcp.NewInternalIPAM(role, &scope)
+	assert.NoError(t, err)
+
+	next := ipam.NextFreeAddress("test")
+	assert.NotNil(t, next)
+	assert.Equal(t, tests.MustParseNetIP(t, "10.200.0.100"), *next)
+}
+
+func TestIPAMInternal_NextFreeAddress_UniqueParallel(t *testing.T) {
+	defer tests.Setup(t)()
+	rootInst := instance.New()
+	ctx := tests.Context()
+	inst := rootInst.ForRole("dhcp", ctx)
+
+	iter := 100
+	addrs := make(chan string, iter)
+
+	scope := testScope()
+
+	tests.PanicIfError(inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyScopes,
+			scope.Name,
+		).String(),
+		tests.MustJSON(scope),
+	))
+	// Create fake leases to test against
+	for i := 0; i < iter-10; i++ {
+		lease := testLease()
+		lease.Address = fmt.Sprintf("192.0.2.%d", 100+i)
+		lease.Identifier = fmt.Sprintf("test_%d", i)
+		lease.ScopeKey = scope.Name
+		tests.PanicIfError(inst.KV().Put(
+			ctx,
+			inst.KV().Key(
+				types.KeyRole,
+				types.KeyLeases,
+				lease.Identifier,
+			).String(),
+			tests.MustJSON(lease),
+		))
+	}
+
+	role := dhcp.New(inst)
+	tests.PanicIfError(role.Start(ctx, []byte(tests.MustJSON(dhcp.RoleConfig{
+		Port: 1067,
+	}))))
+	defer role.Stop()
+	ipam, err := dhcp.NewInternalIPAM(role, &scope)
+	assert.NoError(t, err)
+
+	wg := sync.WaitGroup{}
+	wg.Add(iter)
+	tester := func(idx int) {
+		next := ipam.NextFreeAddress(fmt.Sprintf("test_%d", idx))
+		assert.NotNil(t, next, "Iter %d", idx)
+		addrs <- next.String()
+		wg.Done()
+	}
+	for i := 0; i < iter; i++ {
+		tester(i)
+	}
+	wg.Wait()
+	close(addrs)
+	ips := map[string]int{}
+	assert.Len(t, addrs, iter)
+	for ip := range addrs {
+		ips[ip] += 1
+	}
+	dupes := []string{}
+	for ip, occur := range ips {
+		if occur > 1 {
+			dupes = append(dupes, ip)
+		}
+	}
+	assert.Len(t, maps.Keys(ips), iter, "Addresses: %v, duplicates: %v", maps.Keys(ips), dupes)
+	assert.Len(t, dupes, 0, "Addresses: %v, duplicates: %v", maps.Keys(ips), dupes)
+}

--- a/pkg/roles/dhcp/ipam_internal_test.go
+++ b/pkg/roles/dhcp/ipam_internal_test.go
@@ -94,7 +94,7 @@ func TestIPAMInternal_NextFreeAddress_UniqueParallel(t *testing.T) {
 		wg.Done()
 	}
 	for i := 0; i < iter; i++ {
-		tester(i)
+		go tester(i)
 	}
 	wg.Wait()
 	close(addrs)

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/netip"
 	"runtime"
 	"strings"
 	"testing"
@@ -37,6 +38,12 @@ func MustJSON(in interface{}) string {
 		panic(err)
 	}
 	return string(j)
+}
+
+func MustParseNetIP(t *testing.T, r string) netip.Addr {
+	i, err := netip.ParseAddr(r)
+	assert.NoError(t, err)
+	return i
 }
 
 func Context() context.Context {


### PR DESCRIPTION
Rework the inbuilt IPAM to prevent race conditions leading to the same IP being given out multiple times to different devices

closes #871