### PR TITLE
ci(build): add labels to docker images

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -28,6 +28,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: vars
         run: make ci--env
+      - id: meta
+        uses: docker/metadata-action@v5.6.1
       - uses: docker/build-push-action@v6.10.0
         with:
           tags: |
@@ -39,6 +41,7 @@ jobs:
           build-args: |
             BUILD=${{ steps.vars.outputs.build }}
             GIT_BUILD_HASH=${{ steps.vars.outputs.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
       - uses: actions/create-release@v1.1.4
         id: create_release
         env:

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -30,6 +30,11 @@ jobs:
         run: make ci--env
       - id: meta
         uses: docker/metadata-action@v5.6.1
+        with:
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=v${{ steps.vars.outputs.version }}
       - uses: docker/build-push-action@v6.10.0
         with:
           tags: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: vars
         run: make ci--env
+      - id: meta
+        uses: docker/metadata-action@v5.6.1
       - uses: docker/build-push-action@v6.10.0
         with:
           tags: |
@@ -39,6 +41,7 @@ jobs:
           build-args: |
             BUILD=${{ steps.vars.outputs.build }}
             GIT_BUILD_HASH=${{ steps.vars.outputs.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
   build-cli:
     name: Build CLI
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ jobs:
         run: make ci--env
       - id: meta
         uses: docker/metadata-action@v5.6.1
+        with:
+          flavor: |
+            latest=true
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.sha }}
       - uses: docker/build-push-action@v6.10.0
         with:
           tags: |


### PR DESCRIPTION
Adds `docker/metadata-action` step to generate labels for Docker image builds.