### PR TITLE
dns: fix CNAME answer, mixed-case queries and more

### DIFF
--- a/hack/tests/coredns/Corefile
+++ b/hack/tests/coredns/Corefile
@@ -11,5 +11,4 @@
         10.200.0.6 dex.t.gravity.beryju.io
         fe80::1 ipv6.t.gravity.beryju.io
     }
-    cache 30
 }

--- a/pkg/roles/dns/api_records.go
+++ b/pkg/roles/dns/api_records.go
@@ -70,7 +70,7 @@ func (r *Role) APIRecordsGet() usecase.Interactor {
 			output.Records = append(output.Records, APIRecord{
 				UID:          rec.uid,
 				Hostname:     rec.Name,
-				FQDN:         rec.Name + "." + zone.Name,
+				FQDN:         rec.Name + types.DNSSep + zone.Name,
 				Type:         rec.Type,
 				Data:         rec.Data,
 				MXPreference: rec.MXPreference,

--- a/pkg/roles/dns/api_records_test.go
+++ b/pkg/roles/dns/api_records_test.go
@@ -6,6 +6,7 @@ import (
 	"beryju.io/gravity/pkg/instance"
 	"beryju.io/gravity/pkg/roles/dns"
 	"beryju.io/gravity/pkg/roles/dns/types"
+	"beryju.io/gravity/pkg/roles/dns/utils"
 	"beryju.io/gravity/pkg/tests"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +18,7 @@ func TestAPIRecordsGet(t *testing.T) {
 	inst := rootInst.ForRole("dns", ctx)
 	role := dns.New(inst)
 
-	zone := tests.RandomString() + "."
+	zone := utils.EnsureTrailingPeriod(tests.RandomString())
 	tests.PanicIfError(inst.KV().Put(
 		ctx,
 		inst.KV().Key(
@@ -55,7 +56,7 @@ func TestAPIRecordsPut(t *testing.T) {
 	inst := rootInst.ForRole("dns", ctx)
 	role := dns.New(inst)
 
-	name := tests.RandomString() + "."
+	name := utils.EnsureTrailingPeriod(tests.RandomString())
 	tests.PanicIfError(inst.KV().Put(
 		ctx,
 		inst.KV().Key(
@@ -95,7 +96,7 @@ func TestAPIRecordsDelete(t *testing.T) {
 	inst := rootInst.ForRole("dns", ctx)
 	role := dns.New(inst)
 
-	zone := tests.RandomString() + "."
+	zone := utils.EnsureTrailingPeriod(tests.RandomString())
 	tests.PanicIfError(inst.KV().Put(
 		ctx,
 		inst.KV().Key(

--- a/pkg/roles/dns/api_zones.go
+++ b/pkg/roles/dns/api_zones.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"beryju.io/gravity/pkg/roles/dns/types"
+	"beryju.io/gravity/pkg/roles/dns/utils"
 	"github.com/swaggest/usecase"
 	"github.com/swaggest/usecase/status"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -105,10 +106,7 @@ type APIZonesPutInput struct {
 func (r *Role) APIZonesPut() usecase.Interactor {
 	u := usecase.NewInteractor(func(ctx context.Context, input APIZonesPutInput, output *struct{}) error {
 		z := r.newZone(input.Name)
-		z.Name = input.Name
-		if !strings.HasSuffix(z.Name, ".") {
-			z.Name += "."
-		}
+		z.Name = utils.EnsureTrailingPeriod(input.Name)
 		z.Authoritative = input.Authoritative
 		z.HandlerConfigs = input.HandlerConfigs
 		z.DefaultTTL = input.DefaultTTL

--- a/pkg/roles/dns/api_zones_test.go
+++ b/pkg/roles/dns/api_zones_test.go
@@ -43,7 +43,7 @@ func TestAPIZonesPut(t *testing.T) {
 
 	name := utils.EnsureTrailingPeriod(tests.RandomString())
 	assert.NoError(t, role.APIZonesPut().Interact(ctx, dns.APIZonesPutInput{
-		Name:          strings.TrimSuffix(name, "."),
+		Name:          strings.TrimSuffix(name, types.DNSSep),
 		Authoritative: true,
 		HandlerConfigs: []map[string]interface{}{
 			{

--- a/pkg/roles/dns/api_zones_test.go
+++ b/pkg/roles/dns/api_zones_test.go
@@ -7,6 +7,7 @@ import (
 	"beryju.io/gravity/pkg/instance"
 	"beryju.io/gravity/pkg/roles/dns"
 	"beryju.io/gravity/pkg/roles/dns/types"
+	"beryju.io/gravity/pkg/roles/dns/utils"
 	"beryju.io/gravity/pkg/tests"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,7 +41,7 @@ func TestAPIZonesPut(t *testing.T) {
 	inst := rootInst.ForRole("dns", ctx)
 	role := dns.New(inst)
 
-	name := tests.RandomString() + "."
+	name := utils.EnsureTrailingPeriod(tests.RandomString())
 	assert.NoError(t, role.APIZonesPut().Interact(ctx, dns.APIZonesPutInput{
 		Name:          strings.TrimSuffix(name, "."),
 		Authoritative: true,
@@ -77,7 +78,7 @@ func TestAPIZonesDelete(t *testing.T) {
 	inst := rootInst.ForRole("dns", ctx)
 	role := dns.New(inst)
 
-	name := tests.RandomString() + "."
+	name := utils.EnsureTrailingPeriod(tests.RandomString())
 
 	tests.PanicIfError(inst.KV().Put(
 		ctx,

--- a/pkg/roles/dns/dns_handler.go
+++ b/pkg/roles/dns/dns_handler.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 
+	"beryju.io/gravity/pkg/roles/dns/types"
 	"beryju.io/gravity/pkg/roles/dns/utils"
 	"github.com/getsentry/sentry-go"
 	"github.com/miekg/dns"
@@ -84,7 +85,7 @@ func (ro *Role) rootHandler(w dns.ResponseWriter, r *utils.DNSRequest) {
 		ro.zonesM.RUnlock()
 	}
 	if longestZone == nil {
-		longestZone = ro.zones["."]
+		longestZone = ro.zones[types.DNSRootZone]
 	}
 	if longestZone == nil {
 		ro.log.Error("no matching zone and no global zone")

--- a/pkg/roles/dns/handler_coredns_test.go
+++ b/pkg/roles/dns/handler_coredns_test.go
@@ -28,7 +28,7 @@ func TestRoleDNSHandlerCoreDNS(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{

--- a/pkg/roles/dns/handler_coredns_test.go
+++ b/pkg/roles/dns/handler_coredns_test.go
@@ -1,7 +1,6 @@
 package dns_test
 
 import (
-	"net"
 	"testing"
 
 	"beryju.io/gravity/pkg/instance"
@@ -46,16 +45,11 @@ func TestRoleDNSHandlerCoreDNS(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "example.org.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "example.org.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.0.0.1").String(), ans.(*d.A).A.String())
+	}, "example.org.	IN	A	10.0.0.1")
 }

--- a/pkg/roles/dns/handler_etcd.go
+++ b/pkg/roles/dns/handler_etcd.go
@@ -140,12 +140,14 @@ func (eh *EtcdHandler) Handle(w *utils.FakeDNSWriter, r *utils.DNSRequest) *dns.
 			un,
 			r,
 		)
-		if len(cnames) > 0 {
-			// For each cname, lookup the actual record
+		// For each CNAME, lookup the actual record
+		// only lookup related names if the query wasn't directly for CNAMEs
+		if len(cnames) > 0 && r.Question[0].Qtype != dns.TypeCNAME {
 			for _, _cn := range cnames {
 				cn := _cn.(*dns.CNAME)
 				nq := dns.Question{
-					Name: cn.Target,
+					Name:   cn.Target,
+					Qclass: dns.ClassINET,
 				}
 				nr := utils.NewFakeDNSWriter(w)
 				r.Meta().ResolveRequest(nr, r.Chain(&dns.Msg{Question: []dns.Question{nq}}))

--- a/pkg/roles/dns/handler_etcd.go
+++ b/pkg/roles/dns/handler_etcd.go
@@ -153,6 +153,7 @@ func (eh *EtcdHandler) Handle(w *utils.FakeDNSWriter, r *utils.DNSRequest) *dns.
 				r.Meta().ResolveRequest(nr, r.Chain(&dns.Msg{Question: []dns.Question{nq}}))
 				m.Answer = append(m.Answer, nr.Msg().Answer...)
 			}
+			m.Answer = append(m.Answer, cnames...)
 		}
 	}
 	if len(m.Answer) < 1 {

--- a/pkg/roles/dns/handler_etcd.go
+++ b/pkg/roles/dns/handler_etcd.go
@@ -66,7 +66,7 @@ func (eh *EtcdHandler) findWildcard(r *utils.DNSRequest, relRecordName string, q
 	// Assuming the question is foo.bar.baz and the zone is baz,
 	// we'll try replacing all names from left to right by starts and query with that
 	wildcardName := relRecordName
-	parts := strings.Split(relRecordName, ".")
+	parts := strings.Split(relRecordName, types.DNSSep)
 	for _, part := range parts {
 		// Replace the current dot part with a wildcard (make sure to only replace 1 occurrence,
 		// since we replace from left to right)
@@ -91,7 +91,7 @@ func (eh *EtcdHandler) handleSingleQuestion(question dns.Question, r *utils.DNSR
 	} else {
 		// Otherwise the relative record name still has a dot at the end which is not what we store
 		// in the database
-		relRecordName = strings.TrimSuffix(relRecordName, ".")
+		relRecordName = strings.TrimSuffix(relRecordName, types.DNSSep)
 	}
 	directRecordKey := eh.z.inst.KV().Key(
 		eh.z.etcdKey,

--- a/pkg/roles/dns/handler_etcd.go
+++ b/pkg/roles/dns/handler_etcd.go
@@ -150,7 +150,7 @@ func (eh *EtcdHandler) Handle(w *utils.FakeDNSWriter, r *utils.DNSRequest) *dns.
 					Qclass: dns.ClassINET,
 				}
 				nr := utils.NewFakeDNSWriter(w)
-				r.Meta().ResolveRequest(nr, r.Chain(&dns.Msg{Question: []dns.Question{nq}}))
+				r.Meta().ResolveRequest(nr, r.Chain(&dns.Msg{Question: []dns.Question{nq}}, r.Context(), r.Meta()))
 				m.Answer = append(m.Answer, nr.Msg().Answer...)
 			}
 			m.Answer = append(m.Answer, cnames...)

--- a/pkg/roles/dns/handler_etcd.go
+++ b/pkg/roles/dns/handler_etcd.go
@@ -87,7 +87,7 @@ func (eh *EtcdHandler) handleSingleQuestion(question dns.Question, r *utils.DNSR
 	relRecordName := strings.TrimSuffix(strings.ToLower(question.Name), strings.ToLower(eh.z.Name))
 	if relRecordName == "" {
 		// If the query name was the zone, the query should look for a record at the root
-		relRecordName = types.DNSRoot
+		relRecordName = types.DNSRootRecord
 	} else {
 		// Otherwise the relative record name still has a dot at the end which is not what we store
 		// in the database

--- a/pkg/roles/dns/handler_etcd_test.go
+++ b/pkg/roles/dns/handler_etcd_test.go
@@ -410,17 +410,36 @@ func TestRoleDNS_Etcd_CNAME_Recursive(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
+	AssertDNS(t, role,
+		[]d.Question{
 			{
 				Name:   "foo.example.com.",
-				Qtype:  d.TypeCNAME,
+				Qtype:  d.TypeA,
 				Qclass: d.ClassINET,
 			},
 		},
-	})
-	assert.Len(t, fw.Msg().Answer, 2)
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+		"bar.example.net.	0	IN	CNAME	foo.example.com.",
+		"foo.example.com.	0	IN	CNAME	bar.example.net.",
+	)
 }
 
 func TestRoleDNS_Etcd_WildcardNested(t *testing.T) {

--- a/pkg/roles/dns/handler_etcd_test.go
+++ b/pkg/roles/dns/handler_etcd_test.go
@@ -575,7 +575,6 @@ func TestRoleDNS_Etcd_MixedCase_Reverse(t *testing.T) {
 				Qclass: d.ClassINET,
 			},
 		},
-		// FIXME: should be all lowercase
-		"bar.eXaMpLe.CoM.	0	IN	A	10.1.2.3",
+		"bar.example.com.	0	IN	A	10.1.2.3",
 	)
 }

--- a/pkg/roles/dns/handler_forward_blocky_test.go
+++ b/pkg/roles/dns/handler_forward_blocky_test.go
@@ -86,6 +86,6 @@ func TestRoleDNS_BlockyForwarder_Allow(t *testing.T) {
 				Qclass: d.ClassINET,
 			},
 		},
-		"gravity.beryju.io.	0	IN	A	10.0.0.1",
+		"gravity.beryju.io.	3600	IN	A	10.0.0.1",
 	)
 }

--- a/pkg/roles/dns/handler_forward_blocky_test.go
+++ b/pkg/roles/dns/handler_forward_blocky_test.go
@@ -21,7 +21,7 @@ func TestRoleDNS_BlockyForwarder(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{
@@ -60,7 +60,7 @@ func TestRoleDNS_BlockyForwarder_Allow(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{

--- a/pkg/roles/dns/handler_forward_blocky_test.go
+++ b/pkg/roles/dns/handler_forward_blocky_test.go
@@ -1,7 +1,6 @@
 package dns_test
 
 import (
-	"net"
 	"testing"
 
 	"beryju.io/gravity/pkg/instance"
@@ -39,18 +38,16 @@ func TestRoleDNS_BlockyForwarder(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
+	AssertDNS(t, role,
+		[]d.Question{
 			{
 				Name:   "gravity.beryju.io.",
 				Qtype:  d.TypeA,
 				Qclass: d.ClassINET,
 			},
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("0.0.0.0").String(), ans.(*d.A).A.String())
+		"gravity.beryju.io.	0	IN	A	0.0.0.0",
+	)
 }
 
 func TestRoleDNS_BlockyForwarder_Allow(t *testing.T) {
@@ -81,16 +78,14 @@ func TestRoleDNS_BlockyForwarder_Allow(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
+	AssertDNS(t, role,
+		[]d.Question{
 			{
 				Name:   "gravity.beryju.io.",
 				Qtype:  d.TypeA,
 				Qclass: d.ClassINET,
 			},
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.0.0.1").String(), ans.(*d.A).A.String())
+		"gravity.beryju.io.	0	IN	A	10.0.0.1",
+	)
 }

--- a/pkg/roles/dns/handler_forward_ip.go
+++ b/pkg/roles/dns/handler_forward_ip.go
@@ -118,7 +118,7 @@ func (ipf *IPForwarderHandler) cacheToEtcd(r *utils.DNSRequest, query dns.Questi
 	}
 	name := strings.TrimSuffix(ans.Header().Name, utils.EnsureLeadingPeriod(ipf.z.Name))
 	if strings.EqualFold(ans.Header().Name, ipf.z.Name) {
-		name = types.DNSRoot
+		name = types.DNSRootRecord
 	}
 	record := ipf.z.newRecord(name, dns.TypeToString[ans.Header().Rrtype])
 	switch v := ans.(type) {

--- a/pkg/roles/dns/handler_forward_ip_test.go
+++ b/pkg/roles/dns/handler_forward_ip_test.go
@@ -23,7 +23,7 @@ func TestRoleDNS_IPForwarder_v4(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{
@@ -58,7 +58,7 @@ func TestRoleDNS_IPForwarder_v4_Cache(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{
@@ -92,7 +92,7 @@ func TestRoleDNS_IPForwarder_v4_Cache(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 			"gravity.beryju.io",
 			types.DNSRecordTypeA,
 			"0",
@@ -169,7 +169,7 @@ func TestRoleDNS_IPForwarder_v6(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{

--- a/pkg/roles/dns/handler_forward_ip_test.go
+++ b/pkg/roles/dns/handler_forward_ip_test.go
@@ -1,7 +1,6 @@
 package dns_test
 
 import (
-	"net"
 	"testing"
 	"time"
 
@@ -40,18 +39,13 @@ func TestRoleDNS_IPForwarder_v4(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "gravity.beryju.io.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "gravity.beryju.io.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.0.0.1").String(), ans.(*d.A).A.String())
+	}, "gravity.beryju.io.	3600	IN	A	10.0.0.1")
 }
 
 func TestRoleDNS_IPForwarder_v4_Cache(t *testing.T) {
@@ -81,18 +75,13 @@ func TestRoleDNS_IPForwarder_v4_Cache(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "gravity.beryju.io.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "gravity.beryju.io.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.0.0.1").String(), ans.(*d.A).A.String())
+	}, "gravity.beryju.io.	3600	IN	A	10.0.0.1")
 
 	// We don't have a signal for when a record is persisted to the cache
 	// so wait for things to settle
@@ -142,18 +131,13 @@ func TestRoleDNS_IPForwarder_v4_Cache_Zone(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "gravity.beryju.io.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "gravity.beryju.io.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.0.0.1").String(), ans.(*d.A).A.String())
+	}, "gravity.beryju.io.	3600	IN	A	10.0.0.1")
 
 	// We don't have a signal for when a record is persisted to the cache
 	// so wait for things to settle
@@ -201,16 +185,11 @@ func TestRoleDNS_IPForwarder_v6(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "ipv6.t.gravity.beryju.io.",
-				Qtype:  d.TypeAAAA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "ipv6.t.gravity.beryju.io.",
+			Qtype:  d.TypeAAAA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("fe80::1").String(), ans.(*d.AAAA).AAAA.String())
+	}, "ipv6.t.gravity.beryju.io.	3600	IN	AAAA	fe80::1")
 }

--- a/pkg/roles/dns/handler_int_soa_test.go
+++ b/pkg/roles/dns/handler_int_soa_test.go
@@ -21,10 +21,11 @@ func TestRoleDNS_SOA(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			TestZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			Authoritative: true,
+			DefaultTTL:    3600,
 			HandlerConfigs: []map[string]interface{}{
 				{
 					"type": "forward_ip",
@@ -38,16 +39,11 @@ func TestRoleDNS_SOA(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   ".",
-				Qtype:  d.TypeSOA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   TestZone,
+			Qtype:  d.TypeSOA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, ".", ans.(*d.SOA).Ns)
+	}, "example.com.	3600	IN	SOA	example.com. root.example.com. 1337 600 15 5 3600")
 }

--- a/pkg/roles/dns/handler_memory_bench_test.go
+++ b/pkg/roles/dns/handler_memory_bench_test.go
@@ -20,7 +20,7 @@ func BenchmarkRoleDNS_Memory(b *testing.B) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{
@@ -35,7 +35,7 @@ func BenchmarkRoleDNS_Memory(b *testing.B) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 			"foo",
 			types.DNSRecordTypeA,
 			"0",

--- a/pkg/roles/dns/handler_memory_test.go
+++ b/pkg/roles/dns/handler_memory_test.go
@@ -1,7 +1,6 @@
 package dns_test
 
 import (
-	"net"
 	"testing"
 
 	"beryju.io/gravity/pkg/instance"
@@ -52,18 +51,13 @@ func TestRoleDNS_Memory(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "foo.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "foo.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.1.2.3").String(), ans.(*d.A).A.String())
+	}, "foo.	0	IN	A	10.1.2.3")
 }
 
 func TestRoleDNS_Memory_Wildcard(t *testing.T) {
@@ -106,18 +100,13 @@ func TestRoleDNS_Memory_Wildcard(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "foo.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "foo.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.1.2.3").String(), ans.(*d.A).A.String())
+	}, "foo.	0	IN	A	10.1.2.3")
 }
 
 func TestRoleDNS_Memory_CNAME(t *testing.T) {
@@ -239,18 +228,13 @@ func TestRoleDNS_Memory_WildcardNested(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "foo.bar.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "foo.bar.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.1.2.3").String(), ans.(*d.A).A.String())
+	}, "foo.bar.	0	IN	A	10.1.2.3")
 }
 
 func TestRoleDNS_Memory_MixedCase(t *testing.T) {
@@ -293,18 +277,13 @@ func TestRoleDNS_Memory_MixedCase(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "bar.test.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "bar.test.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.1.2.3").String(), ans.(*d.A).A.String())
+	}, "bar.test.	0	IN	A	10.1.2.3")
 }
 
 func TestRoleDNS_Memory_MixedCase_Reverse(t *testing.T) {
@@ -347,16 +326,11 @@ func TestRoleDNS_Memory_MixedCase_Reverse(t *testing.T) {
 	assert.Nil(t, role.Start(ctx, RoleConfig()))
 	defer role.Stop()
 
-	fw := NewNullDNSWriter()
-	role.Handler(fw, &d.Msg{
-		Question: []d.Question{
-			{
-				Name:   "bar.TesT.",
-				Qtype:  d.TypeA,
-				Qclass: d.ClassINET,
-			},
+	AssertDNS(t, role, []d.Question{
+		{
+			Name:   "bar.TesT.",
+			Qtype:  d.TypeA,
+			Qclass: d.ClassINET,
 		},
-	})
-	ans := fw.Msg().Answer[0]
-	assert.Equal(t, net.ParseIP("10.1.2.3").String(), ans.(*d.A).A.String())
+	}, "bar.test.	0	IN	A	10.1.2.3")
 }

--- a/pkg/roles/dns/handler_memory_test.go
+++ b/pkg/roles/dns/handler_memory_test.go
@@ -182,7 +182,20 @@ func TestRoleDNS_Memory_CNAME(t *testing.T) {
 					Qclass: d.ClassINET,
 				},
 			},
-			"foo.text.	0	IN	CNAME	bar.test.",
+			"foo.test.	0	IN	CNAME	bar.test.",
+		)
+	})
+
+	t.Run("Anything", func(t *testing.T) {
+		AssertDNS(t, role,
+			[]d.Question{
+				{
+					Name:   "foo.test.",
+					Qtype:  d.TypeA,
+					Qclass: d.ClassINET,
+				},
+			},
+			"foo.test.	0	IN	CNAME	bar.test.",
 			"bar.test.	0	IN	A	10.2.3.4",
 		)
 	})

--- a/pkg/roles/dns/handler_memory_test.go
+++ b/pkg/roles/dns/handler_memory_test.go
@@ -21,7 +21,7 @@ func TestRoleDNS_Memory(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{
@@ -36,7 +36,7 @@ func TestRoleDNS_Memory(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 			"foo",
 			types.DNSRecordTypeA,
 			"0",
@@ -70,7 +70,7 @@ func TestRoleDNS_Memory_Wildcard(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{
@@ -85,7 +85,7 @@ func TestRoleDNS_Memory_Wildcard(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 			"*",
 			types.DNSRecordTypeA,
 			"0",
@@ -211,7 +211,7 @@ func TestRoleDNS_Memory_WildcardNested(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{
@@ -226,7 +226,7 @@ func TestRoleDNS_Memory_WildcardNested(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 			"*.*",
 			types.DNSRecordTypeA,
 			"0",

--- a/pkg/roles/dns/record.go
+++ b/pkg/roles/dns/record.go
@@ -87,8 +87,8 @@ func (r *Record) RRType() uint16 {
 
 func (r *Record) FQDN(qname string) string {
 	parts := []string{}
-	qnameParts := strings.Split(qname, ".")
-	for idx, lp := range strings.Split(r.Name, ".") {
+	qnameParts := strings.Split(qname, types.DNSSep)
+	for idx, lp := range strings.Split(r.Name, types.DNSSep) {
 		if lp == types.DNSWildcard {
 			parts = append(parts, qnameParts[idx])
 		} else if lp != types.DNSRootRecord {
@@ -98,7 +98,7 @@ func (r *Record) FQDN(qname string) string {
 	if r.zone.Name != types.DNSRootZone {
 		parts = append(parts, r.zone.Name)
 	}
-	return utils.EnsureTrailingPeriod(strings.Join(parts, "."))
+	return utils.EnsureTrailingPeriod(strings.Join(parts, types.DNSSep))
 }
 
 func (r *Record) ToDNS(qname string) dns.RR {

--- a/pkg/roles/dns/record.go
+++ b/pkg/roles/dns/record.go
@@ -91,11 +91,13 @@ func (r *Record) FQDN(qname string) string {
 	for idx, lp := range strings.Split(r.Name, ".") {
 		if lp == types.DNSWildcard {
 			parts = append(parts, qnameParts[idx])
-		} else if lp != types.DNSRoot {
+		} else if lp != types.DNSRootRecord {
 			parts = append(parts, lp)
 		}
 	}
-	parts = append(parts, r.zone.Name)
+	if r.zone.Name != types.DNSRootZone {
+		parts = append(parts, r.zone.Name)
+	}
 	return utils.EnsureTrailingPeriod(strings.Join(parts, "."))
 }
 

--- a/pkg/roles/dns/record.go
+++ b/pkg/roles/dns/record.go
@@ -140,7 +140,7 @@ func (r *Record) ToDNS(qname string) dns.RR {
 	case dns.TypeCNAME:
 		rr = &dns.CNAME{
 			Hdr:    hdr,
-			Target: r.Data,
+			Target: utils.EnsureTrailingPeriod(r.Data),
 		}
 	case dns.TypeTXT:
 		rr = &dns.TXT{

--- a/pkg/roles/dns/role.go
+++ b/pkg/roles/dns/role.go
@@ -49,7 +49,7 @@ func New(instance roles.Instance) *Role {
 	r.i.AddEventListener(types.EventTopicDNSRecordCreateReverse, r.eventHandlerCreateReverse)
 	r.i.AddEventListener(instanceTypes.EventTopicInstanceFirstStart, func(ev *roles.Event) {
 		// On first start create a zone that'll forward to a reasonable default
-		zone := r.newZone(".")
+		zone := r.newZone(types.DNSRootZone)
 		zone.HandlerConfigs = []map[string]interface{}{
 			{
 				"type": "memory",
@@ -93,7 +93,7 @@ func (r *Role) Start(ctx context.Context, config []byte) error {
 
 	dnsMux := dns.NewServeMux()
 	dnsMux.HandleFunc(
-		".",
+		types.DNSRootZone,
 		r.recoverMiddleware(
 			r.loggingMiddleware(
 				r.Handler,

--- a/pkg/roles/dns/role_bench_test.go
+++ b/pkg/roles/dns/role_bench_test.go
@@ -20,7 +20,7 @@ func BenchmarkRoleDNS_DefaultRootZone(b *testing.B) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{

--- a/pkg/roles/dns/types/role.go
+++ b/pkg/roles/dns/types/role.go
@@ -15,9 +15,13 @@ const (
 )
 
 const (
-	DNSWildcard   = "*"
+	DNSWildcard = "*"
+	// Special name for DNS records at the zone apex
 	DNSRootRecord = "@"
-	DNSRootZone   = "."
+	// Special name for the root zone in gravity
+	DNSRootZone = "."
+	// Separator between DNS labels
+	DNSSep = "."
 )
 
 const (

--- a/pkg/roles/dns/types/role.go
+++ b/pkg/roles/dns/types/role.go
@@ -15,8 +15,9 @@ const (
 )
 
 const (
-	DNSWildcard = "*"
-	DNSRoot     = "@"
+	DNSWildcard   = "*"
+	DNSRootRecord = "@"
+	DNSRootZone   = "."
 )
 
 const (

--- a/pkg/roles/dns/utils/request.go
+++ b/pkg/roles/dns/utils/request.go
@@ -40,11 +40,11 @@ func (r *DNSRequest) Iteration() int {
 	return r.iter
 }
 
-func (r *DNSRequest) Chain(msg *dns.Msg) *DNSRequest {
+func (r *DNSRequest) Chain(msg *dns.Msg, ctx context.Context, meta DNSRoutingMeta) *DNSRequest {
 	return &DNSRequest{
 		Msg:     msg,
-		context: r.context,
-		meta:    r.meta,
+		context: ctx,
+		meta:    meta,
 		iter:    r.iter + 1,
 	}
 }

--- a/pkg/roles/dns/utils/utils.go
+++ b/pkg/roles/dns/utils/utils.go
@@ -1,17 +1,21 @@
 package utils
 
-import "strings"
+import (
+	"strings"
+
+	"beryju.io/gravity/pkg/roles/dns/types"
+)
 
 func EnsureTrailingPeriod(name string) string {
-	if strings.HasSuffix(name, ".") {
+	if strings.HasSuffix(name, types.DNSSep) {
 		return name
 	}
-	return name + "."
+	return name + types.DNSSep
 }
 
 func EnsureLeadingPeriod(name string) string {
-	if strings.HasPrefix(name, ".") {
+	if strings.HasPrefix(name, types.DNSSep) {
 		return name
 	}
-	return "." + name
+	return types.DNSSep + name
 }

--- a/pkg/roles/dns/utils_test.go
+++ b/pkg/roles/dns/utils_test.go
@@ -52,5 +52,5 @@ func AssertDNS(t *testing.T, role *dns.Role, q []d.Question, expected ...string)
 		expectedAnswersStr = append(expectedAnswersStr, r.String())
 	}
 	assert.Len(t, givenAnswersStr, len(expectedAnswersStr), "Count of answers is mismatched")
-	assert.ElementsMatch(t, givenAnswersStr, expectedAnswersStr)
+	assert.ElementsMatch(t, givenAnswersStr, expectedAnswersStr, "Given and expected answers mismatch")
 }

--- a/pkg/roles/dns/utils_test.go
+++ b/pkg/roles/dns/utils_test.go
@@ -3,13 +3,16 @@ package dns_test
 import (
 	"errors"
 	"net"
+	"testing"
 
-	"github.com/miekg/dns"
+	"beryju.io/gravity/pkg/roles/dns"
+	d "github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
 )
 
 type NullDNSWriter struct {
 	closed bool
-	msg    *dns.Msg
+	msg    *d.Msg
 }
 
 func (nw *NullDNSWriter) LocalAddr() net.Addr {
@@ -19,14 +22,35 @@ func (nw *NullDNSWriter) LocalAddr() net.Addr {
 func (nw *NullDNSWriter) RemoteAddr() net.Addr {
 	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053}
 }
-func (nw *NullDNSWriter) WriteMsg(msg *dns.Msg) error { nw.msg = msg; return nil }
-func (nw *NullDNSWriter) Write([]byte) (int, error)   { return 0, errors.New("Write not supported") }
-func (nw *NullDNSWriter) Close() error                { nw.closed = true; return nil }
-func (nw *NullDNSWriter) TsigStatus() error           { return nil }
-func (nw *NullDNSWriter) TsigTimersOnly(v bool)       {}
-func (nw *NullDNSWriter) Hijack()                     {}
-func (nw *NullDNSWriter) Msg() *dns.Msg               { return nw.msg }
+func (nw *NullDNSWriter) WriteMsg(msg *d.Msg) error { nw.msg = msg; return nil }
+func (nw *NullDNSWriter) Write([]byte) (int, error) { return 0, errors.New("Write not supported") }
+func (nw *NullDNSWriter) Close() error              { nw.closed = true; return nil }
+func (nw *NullDNSWriter) TsigStatus() error         { return nil }
+func (nw *NullDNSWriter) TsigTimersOnly(v bool)     {}
+func (nw *NullDNSWriter) Hijack()                   {}
+func (nw *NullDNSWriter) Msg() *d.Msg               { return nw.msg }
 
 func NewNullDNSWriter() *NullDNSWriter {
 	return &NullDNSWriter{}
+}
+
+func AssertDNS(t *testing.T, role *dns.Role, q []d.Question, expected ...string) {
+	fw := NewNullDNSWriter()
+	role.Handler(fw, &d.Msg{
+		Question: q,
+	})
+	// Convert given answers and expected answers to strings
+	givenAnswersStr := []string{}
+	for _, a := range fw.Msg().Answer {
+		givenAnswersStr = append(givenAnswersStr, a.String())
+	}
+	expectedAnswersStr := []string{}
+	for _, a := range expected {
+		r, err := d.NewRR(a)
+		assert.NoError(t, err)
+		assert.NotNil(t, r)
+		expectedAnswersStr = append(expectedAnswersStr, r.String())
+	}
+	assert.Len(t, givenAnswersStr, len(expectedAnswersStr), "Count of answers is mismatched")
+	assert.ElementsMatch(t, givenAnswersStr, expectedAnswersStr)
 }

--- a/pkg/roles/dns/zone.go
+++ b/pkg/roles/dns/zone.go
@@ -109,7 +109,10 @@ func (z *Zone) resolve(w dns.ResponseWriter, r *utils.DNSRequest, span *sentry.S
 		hr := utils.NewRequest(r.Msg, ss.Context(), utils.DNSRoutingMeta{
 			HandlerIdx:      idx,
 			HasMoreHandlers: len(z.h)-(idx+1) > 0,
-			ResolveRequest:  z.role.rootHandler,
+			ResolveRequest: func(w dns.ResponseWriter, r *utils.DNSRequest) {
+				z.log.Debug("Next lookup iteration", zap.Int("iter", r.Iteration()+1))
+				z.role.rootHandler(w, r)
+			},
 		})
 
 		handlerReply := handler.Handle(utils.NewFakeDNSWriter(w), hr)
@@ -125,7 +128,6 @@ func (z *Zone) resolve(w dns.ResponseWriter, r *utils.DNSRequest, span *sentry.S
 				Source: z.Hook,
 				Method: "onDNSRequestAfter",
 			}, r, handlerReply)
-			z.log.Debug("final DNS conversation", zap.String("request", r.String()), zap.String("reply", handlerReply.String()))
 			err := w.WriteMsg(handlerReply)
 			if err != nil {
 				z.log.Warn("failed to write response", zap.Error(err))

--- a/pkg/roles/dns/zone.go
+++ b/pkg/roles/dns/zone.go
@@ -106,7 +106,7 @@ func (z *Zone) resolve(w dns.ResponseWriter, r *utils.DNSRequest, span *sentry.S
 		z.log.Debug("sending request to handler", zap.String("handler", handler.Identifier()))
 		ss.SetTag("gravity.dns.handler", handler.Identifier())
 		// Create new request for handler with the correct context
-		hr := utils.NewRequest(r.Msg, ss.Context(), utils.DNSRoutingMeta{
+		hr := r.Chain(r.Msg, ss.Context(), utils.DNSRoutingMeta{
 			HandlerIdx:      idx,
 			HasMoreHandlers: len(z.h)-(idx+1) > 0,
 			ResolveRequest: func(w dns.ResponseWriter, r *utils.DNSRequest) {

--- a/pkg/roles/dns/zone_test.go
+++ b/pkg/roles/dns/zone_test.go
@@ -20,7 +20,7 @@ func TestRoleDNSZoneFind(t *testing.T) {
 		inst.KV().Key(
 			types.KeyRole,
 			types.KeyZones,
-			".",
+			types.DNSRootZone,
 		).String(),
 		tests.MustJSON(dns.Zone{
 			HandlerConfigs: []map[string]interface{}{

--- a/pkg/roles/dns/zone_watch.go
+++ b/pkg/roles/dns/zone_watch.go
@@ -36,7 +36,7 @@ func (r *Role) handleZoneOp(t mvccpb.Event_EventType, kv *mvccpb.KeyValue, ctx c
 			oldZone.StopWatchingRecords()
 		}
 		if !strings.HasSuffix(z.Name, ".") {
-			r.log.Warn("Zone is missing trailing preiod, most likely configured incorrectly", zap.String("name", z.Name))
+			r.log.Warn("Zone is missing trailing period, most likely configured incorrectly", zap.String("name", z.Name))
 		}
 		r.log.Debug("added zone", zap.String("name", z.Name))
 		r.zonesM.Lock()

--- a/pkg/roles/dns/zone_watch.go
+++ b/pkg/roles/dns/zone_watch.go
@@ -35,7 +35,7 @@ func (r *Role) handleZoneOp(t mvccpb.Event_EventType, kv *mvccpb.KeyValue, ctx c
 		if oldZone, ok := r.zones[z.Name]; ok {
 			oldZone.StopWatchingRecords()
 		}
-		if !strings.HasSuffix(z.Name, ".") {
+		if !strings.HasSuffix(z.Name, types.DNSSep) {
 			r.log.Warn("Zone is missing trailing period, most likely configured incorrectly", zap.String("name", z.Name))
 		}
 		r.log.Debug("added zone", zap.String("name", z.Name))


### PR DESCRIPTION
- Improved DNS Testing helpers (already helped find some bugs)
- Fix CNAME records not being added to answer when not explicitly querying CNAME
- Fixed mixed-case queries not returning in the case saved in etcd
- Fixed CNAME recursion limit not applying correctly
- Fix other misc things