### PR TITLE
dhcp: fix reuse after release

### DIFF
--- a/pkg/roles/dhcp/dhcp_handler4_release.go
+++ b/pkg/roles/dhcp/dhcp_handler4_release.go
@@ -1,6 +1,8 @@
 package dhcp
 
 import (
+	"net/netip"
+
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"go.uber.org/zap"
 )
@@ -10,7 +12,13 @@ func (r *Role) HandleDHCPRelease4(req *Request4) *dhcpv4.DHCPv4 {
 	if match == nil || match.IsReservation() {
 		return nil
 	}
-	err := match.Delete(req.Context)
+	ip, err := netip.ParseAddr(match.Address)
+	if err != nil {
+		req.log.Warn("failed to parse address from lease", zap.Error(err))
+	} else {
+		match.scope.ipam.FreeIP(ip)
+	}
+	err = match.Delete(req.Context)
 	if err != nil {
 		req.log.Warn("failed to delete lease", zap.Error(err))
 	} else {

--- a/pkg/roles/dhcp/ipam.go
+++ b/pkg/roles/dhcp/ipam.go
@@ -18,6 +18,8 @@ type IPAM interface {
 	GetSubnetMask() net.IPMask
 	// Mark an IP as used
 	UseIP(addr netip.Addr, identifier string)
+	// Mark an IP as unused
+	FreeIP(ip netip.Addr)
 	// Update config when scope is updated
 	UpdateConfig(s *Scope) error
 	// Amount of usable IPs excluding any exclusions

--- a/pkg/roles/dhcp/ipam_internal.go
+++ b/pkg/roles/dhcp/ipam_internal.go
@@ -117,6 +117,12 @@ func (i *InternalIPAM) UseIP(ip netip.Addr, identifier string) {
 	}, true)
 }
 
+func (i *InternalIPAM) FreeIP(ip netip.Addr) {
+	i.ipsm.Lock()
+	defer i.ipsm.Unlock()
+	delete(i.ips, ip.String())
+}
+
 func (i *InternalIPAM) useIP(ip netip.Addr, ipu IPUse, overwrite bool) {
 	i.ipsm.Lock()
 	defer i.ipsm.Unlock()

--- a/pkg/roles/dhcp/ipam_internal.go
+++ b/pkg/roles/dhcp/ipam_internal.go
@@ -133,6 +133,10 @@ func (i *InternalIPAM) IsIPFree(ip netip.Addr, identifier *string) bool {
 	mem := i.ips[ip.String()]
 	i.ipsm.RUnlock()
 	if mem != nil {
+		if identifier != nil && mem.identifier == *identifier {
+			i.log.Debug("allowing", zap.String("ip", ip.String()), zap.String("reason", "existing IP (in memory)"))
+			return true
+		}
 		i.log.Debug("discarding", zap.String("ip", ip.String()), zap.String("reason", "used (in memory)"))
 		return false
 	}


### PR DESCRIPTION
Allow an IP to be re-used by the same device after the device has sent a release request