### PR TITLE
roles/dhcp: Show lease time of reservations in the UI

### DIFF
--- a/api/api/openapi.yaml
+++ b/api/api/openapi.yaml
@@ -2446,6 +2446,7 @@ components:
         scopeKey: scopeKey
         description: description
         expiry: 0
+        reservation: true
         addressLeaseTime: addressLeaseTime
         info:
           vendor: vendor
@@ -2467,6 +2468,8 @@ components:
           type: string
         info:
           $ref: "#/components/schemas/DhcpAPILeaseInfo"
+        reservation:
+          type: boolean
         scopeKey:
           type: string
       required:
@@ -2475,6 +2478,7 @@ components:
       - description
       - hostname
       - identifier
+      - reservation
       - scopeKey
       type: object
     DhcpAPILeaseInfo:
@@ -2523,6 +2527,7 @@ components:
         dnsZone: dnsZone
         description: description
         expiry: 0
+        reservation: true
         addressLeaseTime: addressLeaseTime
       properties:
         address:
@@ -2542,6 +2547,8 @@ components:
         hostname:
           maxLength: 255
           type: string
+        reservation:
+          type: boolean
       required:
       - address
       - addressLeaseTime

--- a/api/docs/DhcpAPILease.md
+++ b/api/docs/DhcpAPILease.md
@@ -12,13 +12,14 @@ Name | Type | Description | Notes
 **Hostname** | **string** |  | 
 **Identifier** | **string** |  | 
 **Info** | Pointer to [**DhcpAPILeaseInfo**](DhcpAPILeaseInfo.md) |  | [optional] 
+**Reservation** | **bool** |  | 
 **ScopeKey** | **string** |  | 
 
 ## Methods
 
 ### NewDhcpAPILease
 
-`func NewDhcpAPILease(address string, addressLeaseTime string, description string, hostname string, identifier string, scopeKey string, ) *DhcpAPILease`
+`func NewDhcpAPILease(address string, addressLeaseTime string, description string, hostname string, identifier string, reservation bool, scopeKey string, ) *DhcpAPILease`
 
 NewDhcpAPILease instantiates a new DhcpAPILease object
 This constructor will assign default values to properties that have it defined,
@@ -207,6 +208,26 @@ SetInfo sets Info field to given value.
 `func (o *DhcpAPILease) HasInfo() bool`
 
 HasInfo returns a boolean if a field has been set.
+
+### GetReservation
+
+`func (o *DhcpAPILease) GetReservation() bool`
+
+GetReservation returns the Reservation field if non-nil, zero value otherwise.
+
+### GetReservationOk
+
+`func (o *DhcpAPILease) GetReservationOk() (*bool, bool)`
+
+GetReservationOk returns a tuple with the Reservation field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetReservation
+
+`func (o *DhcpAPILease) SetReservation(v bool)`
+
+SetReservation sets Reservation field to given value.
+
 
 ### GetScopeKey
 

--- a/api/docs/DhcpAPILeasesPutInput.md
+++ b/api/docs/DhcpAPILeasesPutInput.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **DnsZone** | Pointer to **string** |  | [optional] 
 **Expiry** | Pointer to **int64** |  | [optional] 
 **Hostname** | **string** |  | 
+**Reservation** | Pointer to **bool** |  | [optional] 
 
 ## Methods
 
@@ -164,6 +165,31 @@ and a boolean to check if the value has been set.
 
 SetHostname sets Hostname field to given value.
 
+
+### GetReservation
+
+`func (o *DhcpAPILeasesPutInput) GetReservation() bool`
+
+GetReservation returns the Reservation field if non-nil, zero value otherwise.
+
+### GetReservationOk
+
+`func (o *DhcpAPILeasesPutInput) GetReservationOk() (*bool, bool)`
+
+GetReservationOk returns a tuple with the Reservation field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetReservation
+
+`func (o *DhcpAPILeasesPutInput) SetReservation(v bool)`
+
+SetReservation sets Reservation field to given value.
+
+### HasReservation
+
+`func (o *DhcpAPILeasesPutInput) HasReservation() bool`
+
+HasReservation returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/model_dhcp_api_lease.go
+++ b/api/model_dhcp_api_lease.go
@@ -29,6 +29,7 @@ type DhcpAPILease struct {
 	Hostname         string            `json:"hostname"`
 	Identifier       string            `json:"identifier"`
 	Info             *DhcpAPILeaseInfo `json:"info,omitempty"`
+	Reservation      bool              `json:"reservation"`
 	ScopeKey         string            `json:"scopeKey"`
 }
 
@@ -38,13 +39,14 @@ type _DhcpAPILease DhcpAPILease
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDhcpAPILease(address string, addressLeaseTime string, description string, hostname string, identifier string, scopeKey string) *DhcpAPILease {
+func NewDhcpAPILease(address string, addressLeaseTime string, description string, hostname string, identifier string, reservation bool, scopeKey string) *DhcpAPILease {
 	this := DhcpAPILease{}
 	this.Address = address
 	this.AddressLeaseTime = addressLeaseTime
 	this.Description = description
 	this.Hostname = hostname
 	this.Identifier = identifier
+	this.Reservation = reservation
 	this.ScopeKey = scopeKey
 	return &this
 }
@@ -273,6 +275,30 @@ func (o *DhcpAPILease) SetInfo(v DhcpAPILeaseInfo) {
 	o.Info = &v
 }
 
+// GetReservation returns the Reservation field value
+func (o *DhcpAPILease) GetReservation() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.Reservation
+}
+
+// GetReservationOk returns a tuple with the Reservation field value
+// and a boolean to check if the value has been set.
+func (o *DhcpAPILease) GetReservationOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Reservation, true
+}
+
+// SetReservation sets field value
+func (o *DhcpAPILease) SetReservation(v bool) {
+	o.Reservation = v
+}
+
 // GetScopeKey returns the ScopeKey field value
 func (o *DhcpAPILease) GetScopeKey() string {
 	if o == nil {
@@ -321,6 +347,7 @@ func (o DhcpAPILease) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Info) {
 		toSerialize["info"] = o.Info
 	}
+	toSerialize["reservation"] = o.Reservation
 	toSerialize["scopeKey"] = o.ScopeKey
 	return toSerialize, nil
 }
@@ -335,6 +362,7 @@ func (o *DhcpAPILease) UnmarshalJSON(data []byte) (err error) {
 		"description",
 		"hostname",
 		"identifier",
+		"reservation",
 		"scopeKey",
 	}
 

--- a/api/model_dhcp_api_leases_put_input.go
+++ b/api/model_dhcp_api_leases_put_input.go
@@ -27,6 +27,7 @@ type DhcpAPILeasesPutInput struct {
 	DnsZone          *string `json:"dnsZone,omitempty"`
 	Expiry           *int64  `json:"expiry,omitempty"`
 	Hostname         string  `json:"hostname"`
+	Reservation      *bool   `json:"reservation,omitempty"`
 }
 
 type _DhcpAPILeasesPutInput DhcpAPILeasesPutInput
@@ -219,6 +220,38 @@ func (o *DhcpAPILeasesPutInput) SetHostname(v string) {
 	o.Hostname = v
 }
 
+// GetReservation returns the Reservation field value if set, zero value otherwise.
+func (o *DhcpAPILeasesPutInput) GetReservation() bool {
+	if o == nil || IsNil(o.Reservation) {
+		var ret bool
+		return ret
+	}
+	return *o.Reservation
+}
+
+// GetReservationOk returns a tuple with the Reservation field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DhcpAPILeasesPutInput) GetReservationOk() (*bool, bool) {
+	if o == nil || IsNil(o.Reservation) {
+		return nil, false
+	}
+	return o.Reservation, true
+}
+
+// HasReservation returns a boolean if a field has been set.
+func (o *DhcpAPILeasesPutInput) HasReservation() bool {
+	if o != nil && !IsNil(o.Reservation) {
+		return true
+	}
+
+	return false
+}
+
+// SetReservation gets a reference to the given bool and assigns it to the Reservation field.
+func (o *DhcpAPILeasesPutInput) SetReservation(v bool) {
+	o.Reservation = &v
+}
+
 func (o DhcpAPILeasesPutInput) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -241,6 +274,9 @@ func (o DhcpAPILeasesPutInput) ToMap() (map[string]interface{}, error) {
 		toSerialize["expiry"] = o.Expiry
 	}
 	toSerialize["hostname"] = o.Hostname
+	if !IsNil(o.Reservation) {
+		toSerialize["reservation"] = o.Reservation
+	}
 	return toSerialize, nil
 }
 

--- a/hack/dhcp-test/Dockerfile
+++ b/hack/dhcp-test/Dockerfile
@@ -1,0 +1,97 @@
+# Same build as the repo's top-level Dockerfile, except the "gravity-api" npm
+# package used by the web UI is overlaid with a freshly generated client
+# (see /gen-ts-api at the repo root, produced with:
+#   docker run --rm -v "$(pwd)":/local openapitools/openapi-generator-cli:v7.15.0 generate \
+#     -i /local/schema.yml -g typescript-fetch -o /local/gen-ts-api \
+#     --additional-properties=typescriptThreePlus=true,supportsES6=true,npmName=gravity-api,npmVersion=0.33.0 \
+#     --git-user-id BeryJu --git-repo-id gravity
+# )
+# instead of whatever version is currently published to npm. This is needed
+# while testing backend fields that haven't been released in gravity-api yet
+# (e.g. the DHCP lease `reservation` field) - without this, the web UI would
+# silently drop those fields when parsing API responses.
+#
+# Build context must be the repo root, e.g.:
+#   docker build -f hack/dhcp-test/Dockerfile .
+
+# Stage 0: Build the locally generated gravity-api TS client
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:26 AS ts-client-builder
+
+WORKDIR /client
+COPY ./gen-ts-api/ /client/
+RUN npm install && npm run build
+
+# Stage 1: Build web
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:26 AS web-builder
+
+ENV NODE_ENV=production
+
+WORKDIR /work
+
+COPY ./Makefile /work/Makefile
+COPY ./web/package.json /work/web/package.json
+COPY ./web/package-lock.json /work/web/package-lock.json
+
+RUN make web-install
+
+# Overlay the locally built gravity-api client, replacing the published one
+COPY --from=ts-client-builder /client/ /work/web/node_modules/gravity-api/
+
+COPY ./web /work/web
+
+RUN make web-build
+
+# Stage 2: Prepare external files
+FROM --platform=${BUILDPLATFORM} docker.io/library/ubuntu:26.04 AS downloader
+
+WORKDIR /workspace
+COPY Makefile .
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends make curl ca-certificates tshark && \
+    make internal/resources/macoui internal/resources/blocky internal/resources/tftp
+
+# Stage 3: Build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.26 AS builder
+
+ARG GIT_BUILD_HASH
+ARG TARGETARCH
+ARG GRAVITY_BUILD_ARGS
+
+ENV GIT_BUILD_HASH=$GIT_BUILD_HASH
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=${TARGETARCH}
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go mod download
+
+COPY . .
+COPY --from=downloader /workspace/ /workspace/
+COPY --from=web-builder /work/web/dist/ /workspace/web/dist/
+
+RUN make ${GRAVITY_BUILD_ARGS} docker-build
+
+# Stage 4: Run
+FROM docker.io/library/debian:stable-slim
+
+WORKDIR /
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nmap bash-completion bash ca-certificates && \
+    mkdir -p /etc/bash_completion.d/ && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/ && \
+    mkdir /data && \
+    chown 65532:65532 /data && \
+    echo ". /etc/bash_completion" >> /etc/bash.bashrc
+
+COPY --from=builder /workspace/gravity /bin/gravity
+
+RUN /bin/gravity completion bash > /etc/bash_completion.d/gravity
+
+ENTRYPOINT ["/bin/gravity"]
+CMD [ "server" ]

--- a/hack/dhcp-test/docker-compose.yml
+++ b/hack/dhcp-test/docker-compose.yml
@@ -1,0 +1,52 @@
+---
+# Manual test setup for the DHCP reservation-expiry feature.
+#
+# Brings up a gravity instance with a DHCP scope pre-configured (via
+# IMPORT_CONFIGS, see ./import/dhcp-scope.json) and a client container that
+# immediately requests a real DHCP lease from it, so you can:
+#   1. Open http://localhost:8008 (user: admin, password: gravity-test)
+#   2. Go to DHCP -> test -> Leases and see the client's lease with its expiry
+#   3. Select it and click "Turn to reservation"
+#   4. Confirm the row still shows "Reservation" *and* the last known expiry
+#
+# Run with: docker compose -f hack/dhcp-test/docker-compose.yml up --build
+networks:
+  dhcp-test:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.200.50.0/24
+
+services:
+  gravity:
+    build:
+      context: ../..
+      dockerfile: hack/dhcp-test/Dockerfile
+    hostname: gravity-test
+    environment:
+      ADMIN_TOKEN: gravity-test-token
+      ADMIN_PASSWORD: gravity-test
+      LOG_LEVEL: info,dhcp=debug
+      INSTANCE_IP: 10.200.50.10
+      INSTANCE_LISTEN: 0.0.0.0
+      IMPORT_CONFIGS: file:///import/dhcp-scope.json
+    networks:
+      dhcp-test:
+        ipv4_address: 10.200.50.10
+    ports:
+      - "8008:8008"
+    volumes:
+      - ./import:/import:ro
+
+  host:
+    build:
+      context: ../e2e
+      dockerfile: dhcp-client.Dockerfile
+    depends_on:
+      - gravity
+    networks:
+      - dhcp-test
+    cap_add:
+      - NET_ADMIN
+    command: ["sh", "-c", "ip addr flush eth0 && exec dhclient -v -d eth0"]

--- a/hack/dhcp-test/import/dhcp-scope.json
+++ b/hack/dhcp-test/import/dhcp-scope.json
@@ -1,0 +1,8 @@
+{
+  "entries": [
+    {
+      "key": "/dhcp/scopes/test",
+      "value": "eyJkbnMiOnsiem9uZSI6IiIsInNlYXJjaCI6W10sImFkZFpvbmVJbkhvc3RuYW1lIjpmYWxzZX0sImlwYW0iOnsidHlwZSI6ImludGVybmFsIiwicmFuZ2Vfc3RhcnQiOiIxMC4yMDAuNTAuMTAwIiwicmFuZ2VfZW5kIjoiMTAuMjAwLjUwLjIwMCJ9LCJzdWJuZXRDaWRyIjoiMTAuMjAwLjUwLjAvMjQiLCJvcHRpb25zIjpbXSwidHRsIjo2MDAsImRlZmF1bHQiOnRydWUsImhvb2siOiIifQ=="
+    }
+  ]
+}

--- a/pkg/convert/ms_dhcp/convert.go
+++ b/pkg/convert/ms_dhcp/convert.go
@@ -146,9 +146,9 @@ func (c *Converter) convertReservation(scope string, ctx context.Context, r Rese
 		return fmt.Errorf("failed to parse IP")
 	}
 	lease := api.DhcpAPILeasesPutInput{
-		Address:  r.IPAddress,
-		Hostname: r.Name,
-		Expiry:   api.PtrInt64(-1),
+		Address:     r.IPAddress,
+		Hostname:    r.Name,
+		Reservation: api.PtrBool(true),
 	}
 	_, err := c.a.RolesDhcpAPI.DhcpPutLeases(ctx).Scope(scope).Identifier(c.getIdentifier(r.ClientId)).DhcpAPILeasesPutInput(lease).Execute()
 	return err

--- a/pkg/roles/dhcp/api_leases.go
+++ b/pkg/roles/dhcp/api_leases.go
@@ -27,6 +27,7 @@ type APILease struct {
 	ScopeKey         string        `json:"scopeKey" required:"true"`
 	DNSZone          string        `json:"dnsZone"`
 	Expiry           int64         `json:"expiry"`
+	Reservation      bool          `json:"reservation" required:"true"`
 	Description      string        `json:"description" required:"true"`
 }
 type APILeasesGetOutput struct {
@@ -79,6 +80,7 @@ func (r *Role) APILeasesGet() usecase.Interactor {
 				ScopeKey:         l.ScopeKey,
 				DNSZone:          l.DNSZone,
 				Expiry:           l.Expiry,
+				Reservation:      l.Reservation,
 				Description:      l.Description,
 			}
 			if r.oui != nil {
@@ -109,6 +111,7 @@ type APILeasesPutInput struct {
 	AddressLeaseTime string `json:"addressLeaseTime" required:"true" maxLength:"40"`
 	DNSZone          string `json:"dnsZone" maxLength:"255"`
 	Expiry           int64  `json:"expiry"`
+	Reservation      bool   `json:"reservation"`
 	Description      string `json:"description"`
 }
 
@@ -139,6 +142,7 @@ func (r *Role) APILeasesPut() usecase.Interactor {
 		l.ScopeKey = input.Scope
 		l.DNSZone = input.DNSZone
 		l.Expiry = input.Expiry
+		l.Reservation = input.Reservation
 		l.Description = input.Description
 
 		l.scope = scope

--- a/pkg/roles/dhcp/api_leases_test.go
+++ b/pkg/roles/dhcp/api_leases_test.go
@@ -94,6 +94,94 @@ func TestAPILeasesPut(t *testing.T) {
 	)
 }
 
+func TestAPILeasesPut_Reservation(t *testing.T) {
+	tests.Setup(t)
+	rootInst := instance.New()
+	ctx := tests.Context()
+	inst := rootInst.ForRole("dhcp", ctx)
+	role := dhcp.New(inst)
+
+	scope := testScope()
+	name := tests.RandomString()
+	tests.PanicIfError(inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyScopes,
+			scope.Name,
+		).String(),
+		tests.MustJSON(scope),
+	))
+	assert.NoError(t, role.APILeasesPut().Interact(ctx, dhcp.APILeasesPutInput{
+		Identifier:  name,
+		Scope:       scope.Name,
+		Address:     "192.0.2.1",
+		Hostname:    "gravity.home.arpa",
+		Reservation: true,
+	}, &struct{}{}))
+
+	tests.AssertEtcd(
+		t,
+		inst.KV(),
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyLeases,
+			name,
+		),
+		dhcp.Lease{
+			ScopeKey:    scope.Name,
+			Address:     "192.0.2.1",
+			Hostname:    "gravity.home.arpa",
+			Reservation: true,
+		},
+	)
+}
+
+func TestAPILeasesGet_ReturnsReservationFlag(t *testing.T) {
+	tests.Setup(t)
+	rootInst := instance.New()
+	ctx := tests.Context()
+	inst := rootInst.ForRole("dhcp", ctx)
+	role := dhcp.New(inst)
+
+	scope := testScope()
+	tests.PanicIfError(inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyScopes,
+			scope.Name,
+		).String(),
+		tests.MustJSON(scope),
+	))
+	lease := testLease()
+	lease.ScopeKey = scope.Name
+	lease.Reservation = true
+	tests.PanicIfError(inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyLeases,
+			lease.Identifier,
+		).String(),
+		tests.MustJSON(lease),
+	))
+
+	// Scope lookups during lease parsing are served from the role's in-memory
+	// scope watcher, so it must be started (with the scope already in etcd)
+	// before APILeasesGet can resolve the lease's scope key.
+	tests.PanicIfError(role.Start(ctx, []byte(tests.MustJSON(dhcp.RoleConfig{Port: 0}))))
+	defer role.Stop()
+
+	var output dhcp.APILeasesGetOutput
+	assert.NoError(t, role.APILeasesGet().Interact(ctx, dhcp.APILeasesGetInput{
+		ScopeName: scope.Name,
+	}, &output))
+	if assert.Len(t, output.Leases, 1) {
+		assert.True(t, output.Leases[0].Reservation)
+	}
+}
+
 func TestAPILeasesDelete(t *testing.T) {
 	tests.Setup(t)
 	rootInst := instance.New()

--- a/pkg/roles/dhcp/leases.go
+++ b/pkg/roles/dhcp/leases.go
@@ -35,8 +35,14 @@ type Lease struct {
 	AddressLeaseTime string `json:"addressLeaseTime,omitempty"`
 	ScopeKey         string `json:"scopeKey"`
 	DNSZone          string `json:"dnsZone,omitempty"`
-	// Set to -1 for a reservation
-	Expiry      int64  `json:"expiry"`
+	// Expiry always tracks the actual DHCP lease time handed out to the client,
+	// regardless of Reservation. For reservations this is purely informational:
+	// it does not cause the underlying etcd record to expire.
+	Expiry int64 `json:"expiry"`
+	// Reservation marks this lease as a static reservation, whose etcd record
+	// never expires. Legacy records predating this field used Expiry == -1 to
+	// mean the same thing; leaseFromKV migrates those on read.
+	Reservation bool   `json:"reservation,omitempty"`
 	Description string `json:"description"`
 
 	etcdKey string
@@ -131,6 +137,10 @@ func (r *Role) leaseFromKV(raw *mvccpb.KeyValue) (*Lease, error) {
 		return l, err
 	}
 	l.etcdKey = string(raw.Key)
+	if l.Expiry == -1 {
+		// Migrate legacy reservations that predate the Reservation field
+		l.Reservation = true
+	}
 
 	scope, ok := r.scopes.GetPrefix(l.ScopeKey)
 	if !ok {
@@ -141,7 +151,7 @@ func (r *Role) leaseFromKV(raw *mvccpb.KeyValue) (*Lease, error) {
 }
 
 func (l *Lease) IsReservation() bool {
-	return l.Expiry == -1
+	return l.Reservation
 }
 
 func (l *Lease) Delete(ctx context.Context) error {
@@ -158,14 +168,16 @@ func (l *Lease) Delete(ctx context.Context) error {
 }
 
 func (l *Lease) Put(ctx context.Context, expiry int64, opts ...clientv3.OpOption) error {
-	if expiry > 0 && !l.IsReservation() {
+	if expiry > 0 {
 		l.Expiry = time.Now().Add(time.Duration(expiry) * time.Second).Unix()
 
-		exp, err := l.inst.KV().Grant(ctx, expiry)
-		if err != nil {
-			return err
+		if !l.IsReservation() {
+			exp, err := l.inst.KV().Grant(ctx, expiry)
+			if err != nil {
+				return err
+			}
+			opts = append(opts, clientv3.WithLease(exp.ID))
 		}
-		opts = append(opts, clientv3.WithLease(exp.ID))
 	}
 
 	raw, err := json.Marshal(l)
@@ -196,14 +208,16 @@ func (r *Role) CreateLeaseIfAbsent(ctx context.Context, lease *Lease, expiry int
 	opts := []clientv3.OpOption{}
 	var leaseGrant *clientv3.LeaseGrantResponse
 	var err error
-	if expiry > 0 && !lease.IsReservation() {
+	if expiry > 0 {
 		lease.Expiry = time.Now().Add(time.Duration(expiry) * time.Second).Unix()
 
-		leaseGrant, err = lease.inst.KV().Grant(ctx, expiry)
-		if err != nil {
-			return nil, false, err
+		if !lease.IsReservation() {
+			leaseGrant, err = lease.inst.KV().Grant(ctx, expiry)
+			if err != nil {
+				return nil, false, err
+			}
+			opts = append(opts, clientv3.WithLease(leaseGrant.ID))
 		}
-		opts = append(opts, clientv3.WithLease(leaseGrant.ID))
 	}
 
 	raw, err := json.Marshal(lease)

--- a/pkg/roles/dhcp/leases_internal_test.go
+++ b/pkg/roles/dhcp/leases_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"beryju.io/gravity/pkg/roles/dhcp/types"
 	"beryju.io/gravity/pkg/storage"
@@ -12,6 +13,185 @@ import (
 	"github.com/stretchr/testify/assert"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
+
+func testLeaseScope(t *testing.T, ctx context.Context, inst *dhcpTestInstance, role *Role) *Scope {
+	t.Helper()
+	tests.PanicIfError(inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyScopes,
+			"test",
+		).String(),
+		tests.MustJSON(Scope{
+			SubnetCIDR: "10.100.0.0/24",
+			Default:    true,
+			TTL:        86400,
+			IPAM: map[string]string{
+				"type":        "internal",
+				"range_start": "10.100.0.100",
+				"range_end":   "10.100.0.250",
+			},
+		}),
+	))
+	tests.PanicIfError(role.Start(ctx, []byte(tests.MustJSON(RoleConfig{Port: 0}))))
+	t.Cleanup(role.Stop)
+
+	scope, ok := role.scopes.GetPrefix("test")
+	assert.True(t, ok)
+	assert.NotNil(t, scope)
+	return scope
+}
+
+func TestLease_IsReservation(t *testing.T) {
+	l := &Lease{}
+	assert.False(t, l.IsReservation())
+
+	l.Reservation = true
+	assert.True(t, l.IsReservation())
+}
+
+func TestLeaseFromKV_MigratesLegacyReservation(t *testing.T) {
+	tests.Setup(t)
+	ctx := tests.Context()
+	inst := newDHCPTestInstance(ctx)
+	role := New(inst)
+	testLeaseScope(t, ctx, inst, role)
+
+	identifier := "b2:b7:86:2c:d3:fa"
+	tests.PanicIfError(inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyLeases,
+			identifier,
+		).String(),
+		`{"address":"10.100.0.100","hostname":"legacy","scopeKey":"test","expiry":-1,"description":""}`,
+	))
+
+	res, err := inst.KV().Get(ctx, inst.KV().Key(
+		types.KeyRole,
+		types.KeyLeases,
+		identifier,
+	).String())
+	tests.PanicIfError(err)
+	assert.Len(t, res.Kvs, 1)
+
+	l, err := role.leaseFromKV(res.Kvs[0])
+	assert.NoError(t, err)
+	assert.True(t, l.Reservation)
+	assert.True(t, l.IsReservation())
+}
+
+func TestLeaseFromKV_DoesNotMarkRegularLeaseAsReservation(t *testing.T) {
+	tests.Setup(t)
+	ctx := tests.Context()
+	inst := newDHCPTestInstance(ctx)
+	role := New(inst)
+	testLeaseScope(t, ctx, inst, role)
+
+	identifier := "b2:b7:86:2c:d3:fa"
+	tests.PanicIfError(inst.KV().Put(
+		ctx,
+		inst.KV().Key(
+			types.KeyRole,
+			types.KeyLeases,
+			identifier,
+		).String(),
+		`{"address":"10.100.0.100","hostname":"regular","scopeKey":"test","expiry":1234,"description":""}`,
+	))
+
+	res, err := inst.KV().Get(ctx, inst.KV().Key(
+		types.KeyRole,
+		types.KeyLeases,
+		identifier,
+	).String())
+	tests.PanicIfError(err)
+	assert.Len(t, res.Kvs, 1)
+
+	l, err := role.leaseFromKV(res.Kvs[0])
+	assert.NoError(t, err)
+	assert.False(t, l.IsReservation())
+}
+
+func TestLeasePut_ReservationTracksExpiryWithoutEtcdLease(t *testing.T) {
+	tests.Setup(t)
+	ctx := tests.Context()
+	inst := newDHCPTestInstance(ctx)
+	role := New(inst)
+	scope := testLeaseScope(t, ctx, inst, role)
+
+	lease := role.NewLease("b2:b7:86:2c:d3:fa")
+	lease.scope = scope
+	lease.ScopeKey = scope.Name
+	lease.Address = "10.100.0.100"
+	lease.Reservation = true
+
+	tests.PanicIfError(lease.Put(ctx, 3600))
+
+	assert.Greater(t, lease.Expiry, time.Now().Unix(), "expiry should still be tracked for informational purposes")
+
+	res, err := inst.KV().Get(ctx, inst.KV().Key(
+		types.KeyRole,
+		types.KeyLeases,
+		lease.Identifier,
+	).String())
+	tests.PanicIfError(err)
+	assert.Len(t, res.Kvs, 1)
+	assert.Zero(t, res.Kvs[0].Lease, "reservations must not expire from etcd")
+}
+
+func TestLeasePut_NonReservationAttachesEtcdLease(t *testing.T) {
+	tests.Setup(t)
+	ctx := tests.Context()
+	inst := newDHCPTestInstance(ctx)
+	role := New(inst)
+	scope := testLeaseScope(t, ctx, inst, role)
+
+	lease := role.NewLease("b2:b7:86:2c:d3:fa")
+	lease.scope = scope
+	lease.ScopeKey = scope.Name
+	lease.Address = "10.100.0.100"
+
+	tests.PanicIfError(lease.Put(ctx, 3600))
+
+	res, err := inst.KV().Get(ctx, inst.KV().Key(
+		types.KeyRole,
+		types.KeyLeases,
+		lease.Identifier,
+	).String())
+	tests.PanicIfError(err)
+	assert.Len(t, res.Kvs, 1)
+	assert.NotZero(t, res.Kvs[0].Lease, "regular leases must expire from etcd")
+}
+
+func TestCreateLeaseIfAbsent_ReservationDoesNotAttachEtcdLease(t *testing.T) {
+	tests.Setup(t)
+	ctx := tests.Context()
+	inst := newDHCPTestInstance(ctx)
+	role := New(inst)
+	scope := testLeaseScope(t, ctx, inst, role)
+
+	lease := role.NewLease("b2:b7:86:2c:d3:fa")
+	lease.scope = scope
+	lease.ScopeKey = scope.Name
+	lease.Address = "10.100.0.100"
+	lease.Reservation = true
+
+	created, isNew, err := role.CreateLeaseIfAbsent(ctx, lease, 3600)
+	assert.NoError(t, err)
+	assert.True(t, isNew)
+	assert.NotNil(t, created)
+
+	res, err := inst.KV().Get(ctx, inst.KV().Key(
+		types.KeyRole,
+		types.KeyLeases,
+		lease.Identifier,
+	).String())
+	tests.PanicIfError(err)
+	assert.Len(t, res.Kvs, 1)
+	assert.Zero(t, res.Kvs[0].Lease, "reservations must not expire from etcd")
+}
 
 func TestFindLeaseInStore_GetError(t *testing.T) {
 	tests.Setup(t)

--- a/schema.yml
+++ b/schema.yml
@@ -2062,6 +2062,8 @@ components:
           type: string
         info:
           $ref: '#/components/schemas/DhcpAPILeaseInfo'
+        reservation:
+          type: boolean
         scopeKey:
           type: string
       required:
@@ -2070,6 +2072,7 @@ components:
       - hostname
       - addressLeaseTime
       - scopeKey
+      - reservation
       - description
       type: object
     DhcpAPILeaseInfo:
@@ -2106,6 +2109,8 @@ components:
         hostname:
           maxLength: 255
           type: string
+        reservation:
+          type: boolean
       required:
       - address
       - hostname

--- a/web/src/pages/dhcp/DHCPLeaseForm.ts
+++ b/web/src/pages/dhcp/DHCPLeaseForm.ts
@@ -48,9 +48,11 @@ export class DHCPLeaseForm extends ModelForm<DhcpAPILease, string> {
             data.addressLeaseTime = "0";
         }
         if (!this.instance) {
-            data.expiry = -1;
+            data.expiry = 0;
+            data.reservation = true;
         } else {
             data.expiry = this.instance.expiry;
+            data.reservation = this.instance.reservation;
         }
         if (this.instance && this.needsRecreate(data)) {
             await new RolesDhcpApi(DEFAULT_CONFIG).dhcpDeleteLeases({

--- a/web/src/pages/dhcp/DHCPLeasesPage.ts
+++ b/web/src/pages/dhcp/DHCPLeasesPage.ts
@@ -274,12 +274,14 @@ export class DHCPLeasesPage extends TablePage<DhcpAPILease> {
             html`${
                 item.reservation
                     ? html`<div>Reservation</div>
-                          ${(item.expiry || 0) > 0
-                              ? html`<small>
-                                    Last leased until
-                                    ${new Date((item.expiry || 0) * 1000).toLocaleString()}
-                                </small>`
-                              : nothing}`
+                          ${
+                              (item.expiry || 0) > 0
+                                  ? html`<small>
+                                        Last leased until
+                                        ${new Date((item.expiry || 0) * 1000).toLocaleString()}
+                                    </small>`
+                                  : nothing
+                          }`
                     : html`<div>${new Date((item.expiry || 0) * 1000).toLocaleString()}</div>
                           <small>${formatElapsedTime(new Date((item.expiry || 0) * 1000))}</small>`
             }`,

--- a/web/src/pages/dhcp/DHCPLeasesPage.ts
+++ b/web/src/pages/dhcp/DHCPLeasesPage.ts
@@ -211,7 +211,7 @@ export class DHCPLeasesPage extends TablePage<DhcpAPILease> {
                 .callAction=${async () => {
                     return Promise.all(
                         this.selectedElements.map((item) => {
-                            item.expiry = -1;
+                            item.reservation = true;
                             return new RolesDhcpApi(DEFAULT_CONFIG).dhcpPutLeases({
                                 identifier: item.identifier,
                                 scope: this.scope,
@@ -272,8 +272,14 @@ export class DHCPLeasesPage extends TablePage<DhcpAPILease> {
             html`<pre>${item.identifier}</pre>
                 ${item.info ? html` (${item.info.vendor})` : nothing}`,
             html`${
-                (item.expiry || 0) <= -1
-                    ? html`Reservation`
+                item.reservation
+                    ? html`<div>Reservation</div>
+                          ${(item.expiry || 0) > 0
+                              ? html`<small>
+                                    Last leased until
+                                    ${new Date((item.expiry || 0) * 1000).toLocaleString()}
+                                </small>`
+                              : nothing}`
                     : html`<div>${new Date((item.expiry || 0) * 1000).toLocaleString()}</div>
                           <small>${formatElapsedTime(new Date((item.expiry || 0) * 1000))}</small>`
             }`,


### PR DESCRIPTION
## Summary
- Replace the `Expiry == -1` sentinel for DHCP reservations with an explicit `reservation` boolean field on leases, so a reservation's actual last-issued lease time can still be tracked and shown instead of being overwritten by the sentinel.
- Reservations no longer get an etcd TTL lease attached (so their record never expires), but `Expiry` is still updated on each `Put` for informational display; legacy records with `expiry: -1` are migrated to `reservation: true` on read.
- Update the MS DHCP import converter and the web UI (lease form + leases table) to use the new `reservation` field, and show "last leased until" for reservations that have an actual expiry.

## Test plan
- [x] `pkg/roles/dhcp`: added unit tests for `IsReservation()`, legacy `expiry: -1` migration in `leaseFromKV`, and that `Put`/`CreateLeaseIfAbsent` skip granting an etcd TTL lease for reservations while still tracking `Expiry`.
- [x] `pkg/roles/dhcp`: added API-level tests (`APILeasesPut`/`APILeasesGet`) verifying the `reservation` field round-trips through the API.
- [x] `go test -p 1 ./pkg/roles/dhcp/... ./pkg/convert/...` passes locally against etcd.
- [x ] Manual check of the DHCP leases page in the browser (create/mark a reservation, verify "last leased until" renders).

🤖 Generated with the help of [Claude Code](https://claude.com/claude-code)